### PR TITLE
Parameterize Girder host via entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ COPY bower.json .
 COPY ember-cli-build.js .
 COPY package.json .
 
-RUN sed -i config/environment.js \
-        -e 's|%apiHOST%|https://girder.dev.wholetale.org|'
 RUN sed -i app/templates/common/footer.hbs \
         -e "s/{commit}/$(git log --pretty=format:'%h' -n 1)/"
 
@@ -26,3 +24,9 @@ FROM nginx:latest
 WORKDIR /srv/dashboard
 COPY --from=builder /usr/src/node-app/dist /srv/dashboard/.
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+
+ENV GIRDER_HOST https://girder.dev.wholetale.org
+
+COPY ./entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["dashboard"]

--- a/config/environment.js
+++ b/config/environment.js
@@ -77,7 +77,7 @@ module.exports = function(environment) {
     }
 
     if (environment === 'production') {
-        ENV.apiHost = '%apiHOST%';
+        ENV.apiHost = 'API_HOST';
         ENV.apiPath = 'api/v1';
         ENV.apiUrl = ENV.apiHost + '/' + ENV.apiPath;
     }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if [ "$1" == 'dashboard' ]; then
+   echo "Starting nginx with GIRDER_HOST=$GIRDER_HOST" 
+   sed -i index.html -e "s|API_HOST|$GIRDER_HOST|g"
+   nginx -g 'daemon off;'
+else
+   exec "$@"
+fi


### PR DESCRIPTION
This PR replaces the build-time sed process to replace the Girder API host with a similar replacement process via Docker entrypoint.  Because the index.html is generated and encoded, I've changed the replacement variable name, removing % and changing case.  

I don't have a strategy for leveraging environment variables at container runtime in JS without moving the build process into the entrypoint. 