### PR TITLE
Add links to user guide

### DIFF
--- a/app/components/dashboard/browse/left-panel/template.hbs
+++ b/app/components/dashboard/browse/left-panel/template.hbs
@@ -2,8 +2,11 @@
     <div class="wt paddleboard">
         <h2>
             {{!-- <img src="images/wholetale_logo_sm.png" /> --}}
-            Browse Tales <span class="subtitle">Launch to add to Launched Tales list</span> 
+            Browse Tales <span class="subtitle">Launch to add to Launched Tales list</span>
             <i class="fas fa-expand right" style="cursor: pointer;" {{action 'toggleFullscreen'}}></i>
+            <a href="https://wholetale.readthedocs.io/users_guide/browse.html">
+              <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
+            </a>
         </h2>
     </div>
 

--- a/app/components/dashboard/compose/left-panel/template.hbs
+++ b/app/components/dashboard/compose/left-panel/template.hbs
@@ -3,6 +3,9 @@
         <h2>
             <i class="fas fa-edit left"></i> Compose
             <span class="subtitle">Create a new Tale by pairing a compute environment with a dataset</span>
+            <a href="https://wholetale.readthedocs.io/users_guide/compose.html">
+              <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
+            </a>
         </h2>
     </div>
     <div class="ui segment rounded-bottom composer-container">

--- a/app/components/dashboard/manage/left-panel/template.hbs
+++ b/app/components/dashboard/manage/left-panel/template.hbs
@@ -1,6 +1,11 @@
 <div class="wt panel manage">
     <div class="wt paddleboard">
-        <h2><i class="far fa-hdd"></i> Data <span style="font-style:italic;">Import or link data to use in Tales</span></h2>
+        <h2>
+          <i class="far fa-hdd"></i> Data <span style="font-style:italic;">Import or link data to use in Tales</span>
+          <a href="https://wholetale.readthedocs.io/users_guide/manage.html">
+            <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
+          </a>
+        </h2>
     </div>
 
     <div class="main-row">

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -9,8 +9,10 @@
                     </a>
                 {{/if}}
             </span>
-
-            <i class="fas fa-expand right" style="cursor: pointer;" {{action 'toggleFullscreen'}}></i>
+            <i class="fas fa-expand" style="cursor: pointer;" {{action 'toggleFullscreen'}}></i>
+            <a href="https://wholetale.readthedocs.io/users_guide/run.html">
+              <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
+            </a>
         </h2>
     </div>
     {{#if (eq internalState.currentInstanceId model._id)}}

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -118,6 +118,9 @@ ui.inverted.menu.wt.top {
     border-radius: 50%;
   }
 }
+.item.wt.thin {
+  padding: 0 0;
+}
 
 /* Temporary styling to merge both header menus BEGINS */
 .ui.inverted.menu.wt.top .item:not(.not-nav) {

--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -43,7 +43,13 @@
                 <img src="{{gravatarUrl}}" class="gravatar" />
             </div>
             <label class="item small font not-nav">{{user.firstName}} {{user.lastName}}</label>
-            <a class="item not-nav" {{action 'closeMenu' 'logout'}}>
+            <a class="item wt thin not-nav" target="_blank"
+              href="https://wholetale.readthedocs.io/users_guide/index.html"
+              data-tooltip="Read the Whole Tale User Guide." data-position="bottom right">
+                <i class="info circle white large icon"></i>
+            </a>
+            <a class="item wt thin not-nav" {{action 'closeMenu' 'logout'}} 
+              data-tooltip="Log out from the Whole Tale." data-position="bottom right">
                 <i class="sign out white large icon"></i>
             </a>
         </div>
@@ -81,6 +87,11 @@
                             {{#link-to 'compose' invokeAction=(action 'closeMenu' 'Compose' 'plus')}}
                                 <i class="edit black icon"></i> Compose
                             {{/link-to}}
+                        </li>
+                        <li class="bm-menu-item">
+                            <a href="https://wholetale.readthedocs.io/users_guide/index.html">
+                                <i class="info circle black icon"></i> User Guide
+                            </a>
                         </li>
                         <li class="bm-menu-item">
                             <a {{action 'closeMenu' 'logout'}}>


### PR DESCRIPTION
This PR adds:
* Link to User Guide from top nav bar
* Link to User Guide's subsections from left panels in each view.

TODO:
Icons in the specific views could use tooltips, but I didn't know how to position them properly. They were showing in a wrong place when I used the defaults