### PR TITLE
Environment Section Touch Up

### DIFF
--- a/app/components/ui/files/publish-modal/component.js
+++ b/app/components/ui/files/publish-modal/component.js
@@ -213,8 +213,8 @@ export default Ember.Component.extend({
         Responsible for opening the login dialog for the user. Ideally, we could
         tell when the user finishes logging in so that we know when to fetch the token
         */
-       let url = 'http://cn-stage-2.test.dataone.org/portal/oauth?action=start&target='+config.authRedirect;
-       let newwindow=window.open(url,'auth','height=400,width=450');
+       let url = 'https://cn-stage-2.test.dataone.org/portal/oauth?action=start&target='+config.authRedirect;
+       let newwindow = window.open(url,'auth','height=400,width=450');
     },
 
     loggedIntoDataONE() {

--- a/app/components/ui/files/publish-modal/component.js
+++ b/app/components/ui/files/publish-modal/component.js
@@ -17,16 +17,39 @@ export default Ember.Component.extend({
     // An array that holds a pair, (fileName, fileSize)
     fileList: [],
     // Holds an array of objects that the user cannot be exclude from their package
-    nonOptionalFile: ['tale.yaml', 'environment.zip'],
+    nonOptionalFile: ['tale.yaml', 'environment.tar', 'license.txt'],
     // A map that connects the repository dropdown to a url
     repositoryMapping: {'Development': 'https://dev.nceas.ucsb.edu/knb/d1/mn/'},
     // The url for the published tale. This is set after publication succeeds
     packageUrl: '',
     // The jwt token that allows the user to interact with DataONE
     dataoneJWT: '',
+    // The name of the tale
+    taleName: '',
+
+    didInsertElement() {
+        this._super(...arguments);
+
+        this.getTaleFiles();
+        this.setTaleName();
+    },
+
+    didRender () {
+        // Create the tooltips after the template has been rendered
+        this.create_tooltips();
+    },
 
     setPublishBtnState(state) {
         this.set('enablePublish', state);
+    },
+
+    setTaleName() {
+        let url = config.apiUrl + '/tale/'+ this.get('modalContext') 
+        let self = this;
+        this.get('authRequest').send(url)
+        .then(rep => {
+            self.set('taleName', rep['title'])
+        });
     },
 
     getTaleFiles() {
@@ -113,17 +136,6 @@ export default Ember.Component.extend({
         return promisedParentMeta;
       },
 
-    didInsertElement() {
-        this._super(...arguments);
-
-        this.getTaleFiles();
-    },
-
-    didRender () {
-        // Create the tooltips after the template has been rendered
-        this.create_tooltips();
-    },
-
     create_tooltips() {
         // Creates the popup balloons for the info tooltips
 
@@ -144,7 +156,7 @@ export default Ember.Component.extend({
             hoverable: true,
             html: "Place this tale in the public domain and opt out of copyright protection. \
             For more information, visit the <a href='https://spdx.org/licenses/CC0-1.0.html' target='_blank'>CC0 reference page</a>."
-          });
+        });
 
         // Create the CCBY3 popup
         $('.info.circle.blue.icon.ccby3').popup({
@@ -153,7 +165,7 @@ export default Ember.Component.extend({
             hoverable: true,
             html: "Require that users properly attribute the authors of this tale with the CCBY 3.0 standards. \
             For more information, visit the <a href='https://spdx.org/licenses/CC-BY-3.0.html' target='_blank'>CCBY3 reference page</a>."
-          });
+        });
 
         // Create the CCBY4 popup
         $('.info.circle.blue.icon.ccby4').popup({
@@ -162,7 +174,32 @@ export default Ember.Component.extend({
             hoverable: true,
             html: "Require that users properly attribute the authors of this tale with the CCBY 4.0 standards. \
             For more information, visit the <a href='https://spdx.org/licenses/CC-BY-4.0.html' target='_blank'>CCBY4 reference page</a>."
-          });
+        });
+
+        // Create the popups for the environment files
+        // Create the tale.yaml popup
+        $('.info.circle.blue.icon.tale\\.yaml').popup({
+            position : 'right center',
+            target   : '.info.circle.blue.icon.tale\\.yaml',
+            hoverable: true,
+            html: "This file holds metadata about the tale, such as script execution order and file structure."
+        });
+
+        // Create the environment.tar popup
+        $('.info.circle.blue.icon.environment\\.tar').popup({
+            position : 'right center',
+            target   : '.info.circle.blue.icon.environment\\.tar',
+            hoverable: true,
+            html: "The environment archive holds the information needed to re-create the tale's base virtual machine."
+        });
+
+        // Create the LICENSE popup
+        $('.info.circle.blue.icon.license\\.txt').popup({
+            position : 'right center',
+            target   : '.info.circle.blue.icon.license\\.txt',
+            hoverable: true,
+            html: "Each package is created with a license, which can be selected below."
+        });
     },
 
     joinArray(arr) {

--- a/app/components/ui/files/publish-modal/component.js
+++ b/app/components/ui/files/publish-modal/component.js
@@ -173,8 +173,8 @@ export default Ember.Component.extend({
         Responsible for opening the login dialog for the user. Ideally, we could
         tell when the user finishes logging in so that we know when to fetch the token
         */
-       let url = 'https://cn.dataone.org/portal/oauth?action=start&target='+ENV.authRedirect;
-        let newwindow=window.open(url,'auth','height=400,width=450');
+       let url = 'http://cn-stage-2.test.dataone.org/portal/oauth?action=start&target='+config.authRedirect;
+       let newwindow=window.open(url,'auth','height=400,width=450');
     },
 
     loggedIntoDataONE() {
@@ -208,7 +208,7 @@ export default Ember.Component.extend({
             'taleId=' + self.get('modalContext'),
             'repository=' + self.get('repositoryMapping')[self.get('selectedRepository')],
             'jwt=' + self.get('dataoneJWT'),
-            'licenseId=0'
+            'licenseId='+self.getSelectedLicense()
         ].join('&');
         
         let url = config.apiUrl + '/repository/createPackage' + queryParams;
@@ -229,6 +229,16 @@ export default Ember.Component.extend({
         return;
 },
 
+getSelectedLicense() {
+    // Returns the id of the selected license
+    let selected_radio = $('input[name=license-radio]:checked').parent();
+    if (selected_radio.length) {
+        return selected_radio[0].id;
+    }
+    //If we can't find a checked radio, default to 0
+    return '0';
+  },
+
     actions: {
         publishedClicked(){
             /* 
@@ -239,6 +249,7 @@ export default Ember.Component.extend({
            if (self.get('publishingFinish')) {
             self.openPackage();
            }
+           
            // Disable the button so that it isn't accidentally clicked multiple times
            self.set('enablePublish', false);
 

--- a/app/components/ui/files/publish-modal/component.js
+++ b/app/components/ui/files/publish-modal/component.js
@@ -115,14 +115,54 @@ export default Ember.Component.extend({
 
     didInsertElement() {
         this._super(...arguments);
+
         this.getTaleFiles();
-/*         $('.info.circle.blue.icon').popup({
-          position : 'right center',
-          target   : '.info.circle.blue.icon',
-          hoverable: true,
-          html: "Place this tale in the public domain and opt out of copyright protection. \
-          For more information, visit the <a href='https://spdx.org/licenses/CC0-1.0.html' target='_blank'>CC0 reference page</a>."
-        }); */
+    },
+
+    didRender () {
+        // Create the tooltips after the template has been rendered
+        this.create_tooltips();
+    },
+
+    create_tooltips() {
+        // Creates the popup balloons for the info tooltips
+
+        // Create the popup in the main title
+        $('.info.circle.blue.icon.main').popup({
+            position : 'right center',
+            target   : '.info.circle.blue.icon.main',
+            hoverable: true,
+            html: "Get a citeable DOI by publishing your Tale on <a href='https://www.dataone.org/' target='_blank'>DataONE.</a> \
+            For more information on how to publish and cite your tale, visit the \
+            <a href='http://wholetale.readthedocs.io/users_guide/publish.html' target='_blank'>publishing guide</a>."
+          });
+
+        // Create the CC0 popup
+        $('.info.circle.blue.icon.cc0').popup({
+            position : 'right center',
+            target   : '.info.circle.blue.icon.cc0',
+            hoverable: true,
+            html: "Place this tale in the public domain and opt out of copyright protection. \
+            For more information, visit the <a href='https://spdx.org/licenses/CC0-1.0.html' target='_blank'>CC0 reference page</a>."
+          });
+
+        // Create the CCBY3 popup
+        $('.info.circle.blue.icon.ccby3').popup({
+            position : 'right center',
+            target   : '.info.circle.blue.icon.ccby3',
+            hoverable: true,
+            html: "Require that users properly attribute the authors of this tale with the CCBY 3.0 standards. \
+            For more information, visit the <a href='https://spdx.org/licenses/CC-BY-3.0.html' target='_blank'>CCBY3 reference page</a>."
+          });
+
+        // Create the CCBY4 popup
+        $('.info.circle.blue.icon.ccby4').popup({
+            position : 'right center',
+            target   : '.info.circle.blue.icon.ccby4',
+            hoverable: true,
+            html: "Require that users properly attribute the authors of this tale with the CCBY 4.0 standards. \
+            For more information, visit the <a href='https://spdx.org/licenses/CC-BY-4.0.html' target='_blank'>CCBY4 reference page</a>."
+          });
     },
 
     joinArray(arr) {

--- a/app/components/ui/files/publish-modal/template.hbs
+++ b/app/components/ui/files/publish-modal/template.hbs
@@ -2,7 +2,7 @@
 
 <div class="header">
     <h2>Publish Tale
-        <span><p>Create an immutable copy of your Tale with a DOI <i class="info circle blue icon"></i></p> </span>
+        <span><p>Create an immutable copy of your Tale with a DOI <i class="info circle blue icon main"></i></p> </span>
     </h2>
 </div>
 <hr>
@@ -57,6 +57,7 @@
 </div>
 </div>
 
+<hr>
 {{!-- Accordion menu that lists the files which cannot be removed by the user --}}
 <div class="title">
     <h2>
@@ -87,6 +88,7 @@
 </div>
 </div>
 
+<hr>
 {{!-- Accordion menu that lets the user select a license --}}
 <div class="title">
     <h2>
@@ -102,19 +104,26 @@
             <div class="field">
                 <div class="ui radio checkbox cc0" id='0'>
                     <input type="radio" name="license-radio" checked="checked">
-                    <label>Creative Commons Public Domain CCO <i class="info circle blue icon" ></i> </label> 
+                    <label><img class="ui small image left floated" src="https://d15omoko64skxi.cloudfront.net/wp-content/uploads/2014/01/cc-zero.png">
+                     Creative Commons Public Domain CCO <i class="info circle blue icon cc0"></i></label> 
                 </div>
             </div>
             <div class="field">
                 <div class="ui radio checkbox ccby3" id='1'>
                     <input type="radio" name="license-radio">
-                    <label>Creative Commons Attribution CC-BY 3.0 <i class="info circle blue icon" ></i> </label> 
+                    <label>
+                        <img class="ui small image left floated" src="https://upload.wikimedia.org/wikipedia/commons/1/16/CC-BY_icon.svg">
+                        Creative Commons Attribution CC-BY 3.0 <i class="info circle blue icon ccby3" ></i>
+                    </label> 
                 </div>
             </div>
             <div class="field">
                 <div class="ui radio checkbox ccby4" id='2'>
                     <input type="radio" name="license-radio">
-                    <label>Creative Commons Attribution CC-BY 4.0<i class="info circle blue icon" ></i> </label>
+                    <label>
+                        <img class="ui small image left floated" src="https://upload.wikimedia.org/wikipedia/commons/1/16/CC-BY_icon.svg">
+                        Creative Commons Attribution CC-BY 4.0 <i class="info circle blue icon ccby4" ></i> 
+                    </label>
                 </div>
             </div>
         </div>

--- a/app/components/ui/files/publish-modal/template.hbs
+++ b/app/components/ui/files/publish-modal/template.hbs
@@ -97,28 +97,30 @@
 </div>
 
 <div class="content">
-    <div class="ui form"></div>
+    <div class="ui form">
         <div class="grouped fields">
             <div class="field">
-                <div class="ui radio checkbox">
-                    <input type="radio" name="CC0" checked="checked">
+                <div class="ui radio checkbox cc0" id='0'>
+                    <input type="radio" name="license-radio" checked="checked">
                     <label>Creative Commons Public Domain CCO <i class="info circle blue icon" ></i> </label> 
                 </div>
             </div>
             <div class="field">
-                <div class="ui radio checkbox">
-                    <input type="radio" name="CCBY3">
-                    <label>Attribution CC-BY 3.0 <i class="info circle blue icon" ></i> </label> 
+                <div class="ui radio checkbox ccby3" id='1'>
+                    <input type="radio" name="license-radio">
+                    <label>Creative Commons Attribution CC-BY 3.0 <i class="info circle blue icon" ></i> </label> 
                 </div>
             </div>
             <div class="field">
-                <div class="ui radio checkbox">
-                    <input type="radio" name="CCBY4">
-                        <label>Creative Commons Attribution CC-BY 4.0<i class="info circle blue icon" ></i> </label>
+                <div class="ui radio checkbox ccby4" id='2'>
+                    <input type="radio" name="license-radio">
+                    <label>Creative Commons Attribution CC-BY 4.0<i class="info circle blue icon" ></i> </label>
                 </div>
             </div>
         </div>
     </div>
+</div>
+
 {{/ui-accordion}}
 <hr>
 <div class="actions">

--- a/app/components/ui/files/publish-modal/template.hbs
+++ b/app/components/ui/files/publish-modal/template.hbs
@@ -67,25 +67,29 @@
     <i class="dropdown icon"></i>
 </div>
 
-<div class="content">
-        <div class="ui basic segment">
+<div class="content environment">
+    <div class="ui basic segment">
         <div class="ui list">
             <div class="item">
+                <i class="environment folder icon"></i>
+                <div class="content">
+                    <div class="environment name header">{{taleName}}</div>
                     <div class="list">
                         {{#each nonOptionalFile as |file|}}
-                        <div class="item">
+                            <div class="item">
                                 <label>
                                     <div class="content">
                                         <i class="file icon"></i>
-                                        {{file}} <i class="info circle blue icon" ></i> 
+                                        {{file}} <i class="info circle blue icon {{file}}"></i> 
                                     </div>
                                 </label>
                             </div>
                         {{/each}}
                     </div>
+                </div>
             </div>
+        </div>
     </div>
-</div>
 </div>
 
 <hr>

--- a/app/styles/modals.scss
+++ b/app/styles/modals.scss
@@ -127,3 +127,11 @@
     left:3%;
     font-size:medium;
 }
+
+.publisher .environment.folder.icon {
+    font-size: 25;
+}
+
+.publisher .environment.name.header {
+    font-size: 15pt;
+}


### PR DESCRIPTION
I branched this branch off of `dataone_publishing` which at the time of this PR is still a PR (so you'll see extra commits). The commit that needs to be reviewed is afd6667

## Change 1

I added the license file to the environment files section

## Change 2

I added tooltips for each environment file, briefly describing what that are for. To get the selection right, I added the file name to the end of the div class.

### Change 3

Styling changes to the environment section. I changed the size of the folder and the header text. In addition, I made the header text the name of the tale, which I retrieve from the `tale` endpoint.

Here's a screenshot of what it looks like after these changes.

![screen shot 2018-08-04 at 5 12 06 pm](https://user-images.githubusercontent.com/9289652/43681483-979b6cde-9809-11e8-8fac-096d6968216a.png)
