### PR TITLE
Fix Creative Commons Icon and Add Job Watcher to Nav Bar

### DIFF
--- a/app/components/ui/files/publish-modal/component.js
+++ b/app/components/ui/files/publish-modal/component.js
@@ -182,7 +182,7 @@ export default Ember.Component.extend({
             hoverable: true,
             html: "Get a citeable DOI by publishing your Tale on <a href='https://www.dataone.org/' target='_blank'>DataONE.</a> \
             For more information on how to publish and cite your tale, visit the \
-            <a href='http://wholetale.readthedocs.io/users_guide/publish.html' target='_blank'>publishing guide</a>."
+            <a href='http://wholetale.readthedocs.io/users_guide/publishing.html' target='_blank'>publishing guide</a>."
           });
 
         // Create the CC0 popup
@@ -374,12 +374,11 @@ export default Ember.Component.extend({
 getSelectedLicense() {
     // Returns the id of the selected license
     let selected_radio = $('input[name=license-radio]:checked').parent();
-    debugger;
     if (selected_radio.length) {
         return selected_radio[0].id;
     }
-    //If we can't find a checked radio, default to 0
-    return '0';
+    //If we can't find a checked radio, default to cc0
+    return this.get('licenses').cc0.spdx;
   },
 
   setLicenses() {

--- a/app/components/ui/files/publish-modal/template.hbs
+++ b/app/components/ui/files/publish-modal/template.hbs
@@ -29,7 +29,7 @@
 {{!-- Accordion menu that lists the files which cannot be removed by the user --}}
 <div class="title">
     <h2>
-        <i class="desktop icon"></i>Environment
+        <i class="desktop icon"></i> Environment
             <span>
             Everything required to recreate chosen compute environment - view only 
             <i class="dropdown icon"></i>
@@ -66,7 +66,7 @@
 {{!-- Accordion menu that lets the user select a license --}}
 <div class="title">
     <h2>
-        <i class="creative commons icon"></i>Usage Rights
+        <i class="fab fa-creative-commons"></i> Usage Rights
         <span>
             Choose how you wish your Tale to be stored and reused
             <i class="dropdown icon"></i>

--- a/app/styles/modals.scss
+++ b/app/styles/modals.scss
@@ -149,7 +149,7 @@
       margin-left:10px;
   }
   
-  .publisher .creative.commons.icon {
+  .publisher .fab.fa-creative-commons {
       margin-left:10px;
   }
   

--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -43,6 +43,10 @@
                 <img src="{{gravatarUrl}}" class="gravatar" />
             </div>
             <label class="item small font not-nav">{{user.firstName}} {{user.lastName}}</label>
+            <a class="item wt thin not-nav" data-tooltip="View running tasks."
+                data-position="bottom right" {{action 'openJobWatcher'}}>
+                    <i class="tasks icon white"></i>
+            </a>    
             <a class="item wt thin not-nav" target="_blank"
               href="https://wholetale.readthedocs.io/users_guide/index.html"
               data-tooltip="Read the Whole Tale User Guide." data-position="bottom right">


### PR DESCRIPTION
I switched over to using Font Awesome for the CC icon

I also added the job watcher to the navigation bar
<img width="994" alt="screen shot 2018-08-08 at 3 47 51 pm" src="https://user-images.githubusercontent.com/9289652/43868438-7df0b034-9b22-11e8-8c59-6b390ee11072.png">
<img width="370" alt="screen shot 2018-08-08 at 3 47 59 pm" src="https://user-images.githubusercontent.com/9289652/43868439-7e06fc04-9b22-11e8-9a6d-960e068a2072.png">

