### PR TITLE
Fix License Images

### DIFF
--- a/app/components/ui/files/publish-modal/component.js
+++ b/app/components/ui/files/publish-modal/component.js
@@ -39,15 +39,21 @@ export default Ember.Component.extend({
         'cc0': {
             'name': 'Creative Commons Public Domain CCO',
             'spdx': 'CC0-1.0',
-            'short': 'CC0'},
+            'short': 'CC0',
+            'imageName': '/images/CC0.png'
+        },
         'ccby3': {
             'name': 'Creative Commons Attribution CC-BY 3.0',
             'spdx': 'CC-BY-3.0',
-            'short': 'CC-BY3'},
+            'short': 'CC-BY3',
+            'imageName': '/images/CC-BY3.png'
+        },
         'ccby4': {
             'name': 'Creative Commons Attribution CC-BY 4.0',
             'spdx': 'CC-BY-4.0',
-            'short': 'CC-BY4'},
+            'short': 'CC-BY4',
+            'imageName': '/images/CC-BY4.png'
+        }
         },
     // Filtered list of licenses that are available for selection. This changes when the user
     // changes the selected repository.

--- a/app/components/ui/files/publish-modal/template.hbs
+++ b/app/components/ui/files/publish-modal/template.hbs
@@ -82,7 +82,7 @@
             <div class="field">
                 <div class="ui radio checkbox {{license.short}}" id="{{license.spdx}}">
                     <input type="radio" name="license-radio" checked="checked">
-                    <label><img class="ui small image left floated" src="/images/{{license.short}}.png">
+                    <label><img class="ui small image left floated" src="{{license.imageName}}">
                      {{license.name}} <i class="info circle blue icon {{license.short}}"></i></label> 
                 </div>
             </div>


### PR DESCRIPTION
I was having issues referencing the fingerprinted images with `src="/images/{{license.short}}.png">`. Adding a dict param with the full image path fixed the issue. Fixes #241 