### PR TITLE
Fix file picker jumpiness by fixing the first two columns

### DIFF
--- a/app/components/ui/files/file-picker/folder-contents/template.hbs
+++ b/app/components/ui/files/file-picker/folder-contents/template.hbs
@@ -1,14 +1,14 @@
 <table class="ui striped table file-picker">
   {{#unless parent._parent}}
   <tr>
-    <th style="position:absolute; left:0%;">Entry Point</th>
-    <th></th>
+    <th style="width: 1rem;">Entry Point</th>
+    <th style="width: 1rem;"></th>
     <th>Name</th>
   </tr>
   {{/unless}}
   {{#each parent.folders as |folder|}}
   <tr class="left aligned selectable" id={{folder.id}}>
-    <td style="position:absolute; left:0;">
+    <td style="">
     </td>
     <td>
       {{#unless folder.disallowImport}}
@@ -44,7 +44,7 @@
 
   {{#each parent.files as |file|}}
   <tr class="left aligned selectable" id={{file.id}}>
-    <td style="position:absolute; left:3%;">
+    <td style="position: absolute; left: 1rem;">
       {{#if (eq entryPoint.id file.id)}}
       <i class="far fa-dot-circle clickable" {{action uncheckEntry file on="click"}}></i>
       {{else}}

--- a/app/styles/modals.scss
+++ b/app/styles/modals.scss
@@ -196,3 +196,11 @@
  .table.file-picker tr td {
     border: none;
  }
+
+ .table.file-picker td:nth-child(1) {
+    width: 1rem;
+ }
+
+ .table.file-picker td:nth-child(2) {
+    width: 1rem;
+}


### PR DESCRIPTION
This is such a small change maybe we don't need another set of eyes but just in case I'll leave this open until tomorrow afternoon.

Old behavior:

![kapture 2018-09-05 at 15 32 30](https://user-images.githubusercontent.com/563/45126930-4b972080-b122-11e8-81ec-d0350e4ab3af.gif)


New behavior:

![kapture 2018-09-05 at 15 33 29](https://user-images.githubusercontent.com/563/45126932-4df97a80-b122-11e8-8e40-cca481c22c6c.gif)


Closes #261 

