### PR TITLE
Data import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM risingstack/alpine:3.4-v7.9.0-4.5.0 as builder
+FROM risingstack/alpine:3.7-v8.10.0-4.8.0 as builder
 
 RUN npm -g install bower
 

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -100,7 +100,9 @@ export default Component.extend({
       this.renderExternalPackage();
       // Let the right panel component know that it should disable the file browser
       this.get('wtEvents').events.disableRightPanel();
-      this.get('wtEvents').events.selectEnvironmentByName(this.get('model').queryParams.environment);
+      if (this.get('model').queryParams && this.get('model').queryParams.environment) {
+        this.get('wtEvents').events.selectEnvironmentByName(this.get('model').queryParams.environment);
+      }
       });
   },
 

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -6,6 +6,7 @@ import { later } from '@ember/runloop';
 import Object, { computed } from '@ember/object';
 import { run } from '@ember/runloop';
 import { scheduleOnce } from '@ember/runloop';
+import $ from 'jquery';
 
 export default Component.extend({
   apiCall: service('api-call'),
@@ -65,13 +66,13 @@ export default Component.extend({
       self.set('selectedEnvironment', selectedEnvironment);
     });
 
+    this.setDefaults();
     // Check if we're ingesting a dataset/tale
     if (this.get('model').queryParams.data_location) {
       this.set('importing', true);
       this.setThirdPartyParams();
       this.renderImportInfo();
     }
-    this.setDefaults();
   },
 
   setDefaults() {
@@ -287,7 +288,6 @@ createTaleFromDataset() {
     // Attempt to create a tale from a dataset
     let taleKwargs = new Object();
     taleKwargs.title = this.get('newTaleName').trim()
-    console.log(taleKwargs)
     component.get('apiCall').taleFromDataset(
         this.get('selectedEnvironment').get('_id'),
         this.get('datasetLocation'),
@@ -331,7 +331,7 @@ createTaleFromDataset() {
       let data = this.get('inputData') || {};
       let formattedData = [];
       data.forEach(x => {
-        // Check that the object is a legitimate folder/item
+        // Check that the object is a folder/item
         if (x.hasOwnProperty('id')) {
             formattedData.push({
             'type': x.get('isFolder') ? 'folder' : 'item',
@@ -361,6 +361,5 @@ createTaleFromDataset() {
         this.setDefaults();
         return false;
       },
-
   },
 });

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -48,11 +48,18 @@ export default Component.extend({
       self.set('selectedEnvironment', selectedEnvironment);
     });
 
-    // If the user is coming to this page from a third party with the intent
-    // on importing data, the referrer is set here.
-    self.set('datasetLocation', this.get('model').queryParams.data_location);
-    self.set('datasetProvider', this.get('model').queryParams.data_provider);
-    self.set('packageAPI', this.get('model').queryParams.data_api);
+    this.setThirdPartyParams();
+    this.scheduleDataImport();
+  },
+
+  scheduleDataImport() {
+      /* 
+      Schedule a function that first checks if it needs to handle
+      the case where the page is being landed on by a third party 
+      with a dataset. 
+      Second, it checks which service was the referrer, and directs
+      program flow to the appropriate section for querying the service.
+      */
     scheduleOnce('afterRender', this, () => {
         // Check if we're coming from a third party
         if (this.get('datasetLocation')) {
@@ -72,6 +79,14 @@ export default Component.extend({
             return;
         }
       });
+  },
+
+  setThirdPartyParams() {
+    // If the user is coming to this page from a third party with the intent
+    // on importing data, the referrer is set here.
+    this.set('datasetLocation', this.get('model').queryParams.data_location);
+    this.set('datasetProvider', this.get('model').queryParams.data_provider);
+    this.set('packageAPI', this.get('model').queryParams.data_api);
   },
 
   insertPackageName(allSelected) {

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -92,6 +92,8 @@ export default Component.extend({
     scheduleOnce('afterRender', this, () => {
       // Fill in the dataset title in the Tale Name and Input data fields
       this.renderExternalPackage();
+      // Let the right panel component know that it should disable the file browser
+      this.get('wtEvents').events.disableRightPanel();
       });
   },
 

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -100,6 +100,7 @@ export default Component.extend({
       this.renderExternalPackage();
       // Let the right panel component know that it should disable the file browser
       this.get('wtEvents').events.disableRightPanel();
+      this.get('wtEvents').events.selectEnvironmentByName(this.get('model').queryParams.environment);
       });
   },
 
@@ -113,17 +114,17 @@ export default Component.extend({
   },
 
   /**
-  * Insers the data package name into the selected data.
-  * 
-  * We'll want to check if we need to fake the pending dataset in the
-  * Input data section. This check needs to be made when we replace the 
-  * inputData array with newly (de)selected files.
-  * Inserting the package name should be done when the user is importing a dataset 
-  * to make it clear that their data will be inside the Tale, even though it hasn't 
-  * been registered yet.
-  * @method insertPackageName
-  * @param allSelected Collection of selected data items
-  */
+   * Inserts the data package name into the selected data.
+   * 
+   * We'll want to check if we need to fake the pending dataset in the
+   * Input data section. This check needs to be made when we replace the 
+   * inputData array with newly (de)selected files.
+   * Inserting the package name should be done when the user is importing a dataset 
+   * to make it clear that their data will be inside the Tale, even though it hasn't 
+   * been registered yet.
+   * @method insertPackageName
+   * @param allSelected Collection of selected data items
+   */
   insertPackageName(allSelected) {
 
        let self = this;

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -76,6 +76,10 @@ export default Component.extend({
       this.renderImportInfo();
     }
   },
+  
+  importFileName: computed('datasetURI', function () {
+    return 'Data Source: ' + this.get('datasetURI');
+  }),
 
   /**
    * Resets the GUI.
@@ -149,7 +153,7 @@ export default Component.extend({
    */
   insertPackageName(allSelected) {
     let self = this;
-    let datasetName = self.get('datasetTitle');
+    let datasetName = self.importFileName;
     if (datasetName) {
       // Check if it's in the file listing already
       var exists = false;
@@ -179,7 +183,7 @@ export default Component.extend({
     // Fill in the Input data field. The UI displays 'name' in the UI in the
     // Input data section
     let newDataObj = {
-      name: self.get('datasetTitle')
+      name: self.importFileName
     };
     // self.inputData needs to be taken as an array
     let inputData = A();

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -39,7 +39,7 @@ export default Component.extend({
   // The error message that gets shown on catastrophic failures
   defaultErrorMessage: "There was an error while creating your Tale.",
   // The color of the progress bar
-  barColor:"#11d850",
+  barColor:"#093268",
 
   invalidNewTale: computed('inputData', 'selectedEnvironment', 'newTaleName', 'inputData.length', function () {
     let name = this.get('newTaleName');

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -63,7 +63,9 @@ export default Component.extend({
       self.set('inputData', allSelected);
     });
     events.on('selectEnvironment', function (selectedEnvironment) {
-      self.set('selectedEnvironment', selectedEnvironment);
+      if (self) {
+        self.set('selectedEnvironment', selectedEnvironment);
+      }
     });
 
     this.setDefaults();
@@ -75,6 +77,10 @@ export default Component.extend({
     }
   },
 
+  /**
+   * Resets the GUI.
+   * @method getFinalJobStatus
+   */
   setDefaults() {
     // Set default values of mutable variables
     this.set('progress', 0);
@@ -106,16 +112,20 @@ export default Component.extend({
     this.set('environment', this.get('model').queryParams.environment);
   },
 
+  /**
+  * Insers the data package name into the selected data.
+  * 
+  * We'll want to check if we need to fake the pending dataset in the
+  * Input data section. This check needs to be made when we replace the 
+  * inputData array with newly (de)selected files.
+  * Inserting the package name should be done when the user is importing a dataset 
+  * to make it clear that their data will be inside the Tale, even though it hasn't 
+  * been registered yet.
+  * @method insertPackageName
+  * @param allSelected Collection of selected data items
+  */
   insertPackageName(allSelected) {
-      /* 
-        We'll want to check if we need to fake the pending dataset in the
-        Input data section. This check needs to be made when we replace the 
-        inputData array with newly (de)selected files.
 
-        Inserting the package name should be done when the user is importing a dataset 
-        to make it clear that their data will be inside the Tale, even though it hasn't 
-        been registered yet.
-      */
        let self = this;
        let datasetName = self.get('datasetTitle');
        if (datasetName) {
@@ -275,8 +285,11 @@ export default Component.extend({
     jobUpdateLoop = startLooping();
 },
 
-createTaleFromDataset() {
-    /* Handles initiating the job to start the dataset import */
+  /**
+  * Handles asking the backend to spawn a new tale import job.
+  * @method createTaleFromDataset
+  */
+  createTaleFromDataset() {
     let component = this;    
     let onFail = (e) => {
         // deal with the failure here
@@ -303,13 +316,19 @@ createTaleFromDataset() {
 
   actions: {
 
-    // this is called when someone selected the front end image/environment
+    /**
+    * Sets the component's selected environment.
+    * @method selectEnvironment
+    */
     selectEnvironment(model) {
       this.set("selectedEnvironment", model);
     },
 
-    createTale() {
-      // Handles the user's click on Create New Tale
+    /**
+    * Handles the user's click to create a new Tale
+    * @method onNewTaleClick
+    */
+   onNewTaleClick() {
       let component = this;
       if (component.launchingInstance) {
         return;
@@ -354,14 +373,14 @@ createTaleFromDataset() {
     },
 
     openErrorModal() {
-        let selector = '.ui.compose-error.modal';
-        $(selector).modal('setting', 'closable', false);
-        $(selector).modal('show');
-      },
+      let selector = '.ui.compose-error.modal';
+      $(selector).modal('setting', 'closable', false);
+      $(selector).modal('show');
+    },
     
-      closeErrorModal() {
-        this.setDefaults();
-        return false;
-      },
+    closeErrorModal() {
+      this.setDefaults();
+      return false;
+    },
   },
 });

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -1,25 +1,44 @@
-import Component from '@ember/component';
-import Object, { computed, observer } from '@ember/object';
-import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
+import { cancel } from '@ember/runloop';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { later } from '@ember/runloop';
+import Object, { computed } from '@ember/object';
 import { run } from '@ember/runloop';
 import { scheduleOnce } from '@ember/runloop';
 
 export default Component.extend({
   apiCall: service('api-call'),
+  // Used to listen for events (like selecting an environment)
   wtEvents: service(),
+  // Used to query girder
   store: service(),
+  // Used to redirect the user to the run page on success
   router: service(),
-
   // Holds an array of Objects which are shown in the `Input data section`
   inputData: A(),
+  // Represents the environment that the user picked
   selectedEnvironment: Object.create({}),
   // The name of the Tale which appears in the UI
   newTaleName: '',
-  message: 'Launching new Tale, please wait.',
+  // The message that the user sees when creating a new tale
+  message: '',
+  // Flag representing the state of the UI (are we currently launching an instance?)
   launchingInstance: false,
   // The title of the dataset which came from a third party
   datasetTitle: '',
+  // The name of the environment that the third party picked
+  environment: '',
+  // The level of progress that is shown in the progress bar
+  progress: 0,
+  // Flag set when we're ingesting a resource from a third party
+  importing: false,
+  // The error message that the user will see if there is an error
+  errorMessage: '',
+  // The error message that gets shown on catastrophic failures
+  defaultErrorMessage: "There was an error while creating your Tale.",
+  // The color of the progress bar
+  barColor:"#11d850",
 
   invalidNewTale: computed('inputData', 'selectedEnvironment', 'newTaleName', 'inputData.length', function () {
     let name = this.get('newTaleName');
@@ -28,7 +47,6 @@ export default Component.extend({
     if (!this.get('inputData')) {
       this.set('inputData', A());
     }
-    // let hasData = Boolean(this.get('inputData') && this.get('inputData').length);
     return !(hasName && hasEnvironment);
   }),
 
@@ -47,24 +65,32 @@ export default Component.extend({
       self.set('selectedEnvironment', selectedEnvironment);
     });
 
-    this.setThirdPartyParams();
-    this.scheduleDataImport();
+    // Check if we're ingesting a dataset/tale
+    if (this.get('model').queryParams.data_location) {
+      this.set('importing', true);
+      this.setThirdPartyParams();
+      this.renderImportInfo();
+    }
+    this.setDefaults();
   },
 
-  scheduleDataImport() {
+  setDefaults() {
+    // Set default values of mutable variables
+    this.set('progress', 0);
+    this.set('launchingInstance', false);
+    this.set('message', 'Launching new Tale, please wait.');
+    this.set('errorMessage', '');
+    this.set('datasetTitle', '');
+  },
+
+  renderImportInfo() {
       /* 
-      Schedule a function that first checks if it needs to handle
-      the case where the page is being landed on by a third party 
-      with a dataset. 
-      Second, it checks which service was the referrer, and directs
-      program flow to the appropriate section for querying the service.
+        Schedules the function that fills in the Tale name to run afterRender
       */
+    
     scheduleOnce('afterRender', this, () => {
-        // Check if we're coming from a third party
-        if (this.get('datasetLocation')) {
-            // Fill in the dataset title in the Tale Name and Input data fields
-            this.addExternalPackage();
-        }
+      // Fill in the dataset title in the Tale Name and Input data fields
+      this.renderExternalPackage();
       });
   },
 
@@ -74,6 +100,7 @@ export default Component.extend({
     this.set('datasetLocation', this.get('model').queryParams.data_location);
     this.set('datasetTitle', this.get('model').queryParams.data_title);
     this.set('packageAPI', this.get('model').queryParams.data_api);
+    this.set('environment', this.get('model').queryParams.environment);
   },
 
   insertPackageName(allSelected) {
@@ -107,7 +134,7 @@ export default Component.extend({
        return allSelected;
   },
 
-  addExternalPackage() {
+  renderExternalPackage() {
         /*
         Fills in the Tale Name and Input data section with the title of the dataset.
         */
@@ -125,7 +152,7 @@ export default Component.extend({
         self.set('inputData', inputData);
   },
 
-  // public_checked : false,
+  // DEVNOTE: Are these used anymore?
   tale_creating: false,
   tale_created: false,
   configuration: JSON.stringify({}),
@@ -141,22 +168,20 @@ export default Component.extend({
 
   launchTale(tale) {
     let component = this;
-
     let onSuccess = function (item) {
       const instance = Object.create(JSON.parse(item));
       const instanceId = instance._id;
-
-      let currentLoop = null;
+      let instanceQueryLoop = null;
       // Poll the status of the instance every second using recursive iteration
       let startLooping = function (func) {
-        return run.later(function () {
-          currentLoop = startLooping(func);
+        return later(function () {
+          instanceQueryLoop = startLooping(func);
           component.get('store').findRecord('instance', instance.get('_id'), { reload: true })
             .then(model => {
               if (model.get('status') === 1) {
                 component.set('launchingInstance', false);
                 component.get('taleLaunched')();
-                run.cancel(currentLoop);
+                cancel(instanceQueryLoop);
 
                 component.get('router').transitionTo('run.view', instanceId);
               }
@@ -164,18 +189,17 @@ export default Component.extend({
         }, 1000);
       };
       //Start polling
-      currentLoop = startLooping();
+      instanceQueryLoop = startLooping();
     };
 
     let onFail = function (item) {
       // deal with the failure here
       item = JSON.parse(item);
-      component.set('launchingInstance', false);
+      component.set('errorMessage', item.message);
+      component.send('openErrorModal');
     };
 
-    // submit: API
-    // httpCommand, taleid, imageId, folderId, instanceId, name, description, isPublic, config
-
+    // Attempt to create the instance
     component.get("apiCall").postInstance(
       tale.get("_id"),
       tale.get("imageId"),
@@ -184,27 +208,120 @@ export default Component.extend({
       onFail);
   },
 
+  trackTaleImport(job) {
+      /* Updates the UI about the status of a tale/dataset that is being
+      ingested & turned into a Tale.
+      */
+    let component = this;
+    let jobUpdateLoop = null;
+    let jobId = job._id;
+
+    // Poll the status of the job every second using recursive iteration
+    let startLooping = function (func) {
+      return run.later(function () {
+        jobUpdateLoop = startLooping(func);
+
+        component.get('store').findRecord('job', jobId, { reload: true })
+          .then(job => {
+            let statusCode = job.get('status');
+            if (statusCode === 3) {
+                // The job completed
+                component.set('launchingInstance', false);
+                component.get('taleLaunched')();
+
+                // Stop querying the job endpoint
+                run.cancel(jobUpdateLoop);
+
+                /* Get the ID of the instance by getting the job status and then
+                transition to the run page, using the ID. */
+                component.get('apiCall').getFinalJobStatus(jobId,
+                    function(res) {
+                        component.get('router').transitionTo('run.view', res.instance._id);
+                    },
+                    function() {
+                        component.set('errorMessage', self.get('defaultErrorMessage'));
+                    }
+                );   
+            }
+            else if (statusCode === 2 || statusCode === 1) {
+              // The job is running or queued
+              if (job.progress) {
+                  // Update the component variables related to progress
+                  component.set('progress', job.progress.current/job.progress.total);
+                  component.set('message', job.progress.message);
+              }
+            }
+            else {
+              // The job was canceled or resulted in an error
+              component.get('apiCall').getFinalJobStatus(jobId,
+                function(res) {
+                  component.set('errorMessage', res);
+                  component.send('openErrorModal');
+                },
+              function() {
+                  component.set('errorMessage', self.get('defaultErrorMessage'));
+                });
+
+              // Stop querying the job endpoint
+              run.cancel(jobUpdateLoop);  
+            }
+            });
+      }, 1000);
+    };
+    //Start polling
+    jobUpdateLoop = startLooping();
+},
+
+createTaleFromDataset() {
+    /* Handles initiating the job to start the dataset import */
+    let component = this;    
+    let onFail = (e) => {
+        // deal with the failure here
+        component.set('errorMessage', e);
+        component.send('openErrorModal');
+      };
+    
+    // If the call succeeds, we'll get a job that we want to keep around
+    let onSuccess = (job) => component.trackTaleImport(job);
+
+    // Attempt to create a tale from a dataset
+    component.get('apiCall').taleFromDataset(
+        this.get('selectedEnvironment').get('_id'),
+        this.get('datasetLocation'),
+        true,
+        null,
+        null,
+        onSuccess,
+        onFail
+    );
+  },
+
   actions: {
-    // this is called when someone selected the front end image/environment
+
     selectEnvironment(model) {
       this.set("selectedEnvironment", model);
     },
 
-    //   Launch new Tale functionality
     createTale() {
+      // Handles the user's click on Create New Tale
       let component = this;
-
       if (component.launchingInstance) {
         return;
       }
 
       component.set('launchingInstance', true);
 
+      if(component.get('importing')) {
+          // If we're importing a tale/dataset, route the behavior to the importing code
+          component.createTaleFromDataset();
+          return;
+      }
       let onSuccess = (item) => component.launchTale(item);
 
-      let onFail = () => {
+      let onFail = (e) => {
         // deal with the failure here
-        component.set('launchingInstance', false);
+        component.set('errorMessage', e)
+        component.send('openErrorModal');
       };
 
       let data = this.get('inputData') || {};
@@ -228,6 +345,18 @@ export default Component.extend({
       });
 
       new_tale.save().then(onSuccess).catch(onFail);
-    }
-  }
+    },
+
+    openErrorModal() {
+        let selector = '.ui.compose-error.modal';
+        $(selector).modal('setting', 'closable', false);
+        $(selector).modal('show');
+      },
+    
+      closeErrorModal() {
+        this.setDefaults();
+        return false;
+      },
+
+  },
 });

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -285,12 +285,15 @@ createTaleFromDataset() {
     let onSuccess = (job) => component.trackTaleImport(job);
 
     // Attempt to create a tale from a dataset
+    let taleKwargs = new Object();
+    taleKwargs.title = this.get('newTaleName').trim()
+    console.log(taleKwargs)
     component.get('apiCall').taleFromDataset(
         this.get('selectedEnvironment').get('_id'),
         this.get('datasetLocation'),
         true,
         null,
-        null,
+        JSON.stringify(taleKwargs),
         onSuccess,
         onFail
     );
@@ -298,6 +301,7 @@ createTaleFromDataset() {
 
   actions: {
 
+    // this is called when someone selected the front end image/environment
     selectEnvironment(model) {
       this.set("selectedEnvironment", model);
     },

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -15,6 +15,7 @@ export default Component.extend({
   newTaleName: '',
   message: 'Launching new Tale, please wait.',
   launchingInstance: false,
+  datasetSource: null,
 
   invalidNewTale: computed('inputData', 'selectedEnvironment', 'newTaleName', 'inputData.length', function () {
     let name = this.get('newTaleName');
@@ -40,6 +41,10 @@ export default Component.extend({
     events.on('selectEnvironment', function (selectedEnvironment) {
       self.set('selectedEnvironment', selectedEnvironment);
     });
+
+    // If the user is coming to this page from a third party with the intent
+    // on importing data, the referrer is set here.
+    self.set('datasetSource', this.get('model').queryParams.data_source);
   },
 
   // just checking the toggle works ...

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -109,10 +109,30 @@ export default Component.extend({
   setThirdPartyParams() {
     // If the user is coming to this page from a third party with the intent
     // on importing data, the referrer is set here.
-    this.set('datasetLocation', this.get('model').queryParams.data_location);
-    this.set('datasetTitle', this.get('model').queryParams.data_title);
-    this.set('packageAPI', this.get('model').queryParams.data_api);
-    this.set('environment', this.get('model').queryParams.environment);
+    let queryParams = this.get('model').queryParams;
+    if (queryParams) {
+      if (queryParams.data_location) {
+        this.set('datasetLocation', queryParams.data_location);
+      }
+      else {
+        this.set('errorMessage', 'There was an error retrieving data from your third party data source. '+ 
+        'Please manually register the dataset and then create the Tale.');
+        this.send('openErrorModal');
+      }
+      if (queryParams.data_title) {
+        this.set('datasetTitle', queryParams.data_title);
+      }
+      else {
+        // Fall back to using the data package URI
+        this.set('datasetTitle', queryParams.data_location);
+      }
+      if (queryParams.data_api) {
+        this.set('packageAPI', queryParams.data_api);
+      }
+      if (queryParams.environment) {
+        this.set('environment', queryParams.environment);
+      }
+    }
   },
 
   /**
@@ -151,21 +171,21 @@ export default Component.extend({
   },
 
   renderExternalPackage() {
-        /*
-        Fills in the Tale Name and Input data section with the title of the dataset.
-        */
-        let self = this;
-        self.set('newTaleName', self.get('datasetTitle'));
-        
-        // Fill in the Input data field. The UI displays 'name' in the UI in the
-        // Input data section
-        let newDataObj = {
-            name: self.get('datasetTitle')
-        };
-        // self.inputData needs to be taken as an array
-        let inputData = A();
-        inputData.push(newDataObj)
-        self.set('inputData', inputData);
+    /*
+    Fills in the Tale Name and Input data section with the title of the dataset.
+    */
+    let self = this;
+    self.set('newTaleName', self.get('datasetTitle'));
+
+    // Fill in the Input data field. The UI displays 'name' in the UI in the
+    // Input data section
+    let newDataObj = {
+      name: self.get('datasetTitle')
+    };
+    // self.inputData needs to be taken as an array
+    let inputData = A();
+    inputData.push(newDataObj)
+    self.set('inputData', inputData);
   },
 
   // DEVNOTE: Are these used anymore?

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -78,7 +78,10 @@ export default Component.extend({
   },
   
   importFileName: computed('datasetURI', function () {
-    return 'Data Source: ' + this.get('datasetURI');
+    if (this.get('datasetURI')) {
+      return 'Data Source: ' + this.get('datasetURI');
+    }
+    return false;
   }),
 
   /**

--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -44,7 +44,8 @@ export default Component.extend({
 
     // If the user is coming to this page from a third party with the intent
     // on importing data, the referrer is set here.
-    self.set('datasetSource', this.get('model').queryParams.data_source);
+    self.set('datasetLocation', this.get('model').queryParams.data_location);
+    self.set('datasetProvider', this.get('model').queryParams.data_provider);
   },
 
   // just checking the toggle works ...

--- a/app/components/dashboard/compose/left-panel/template.hbs
+++ b/app/components/dashboard/compose/left-panel/template.hbs
@@ -16,9 +16,9 @@
   <div class="ui segment rounded-bottom composer-container">
     {{#if launchingInstance}}
       <div class="compose-status">
-          <h1 class ="compose-status-message">
+          <p class ="compose-status-message">
             {{message}}
-          </h1>
+          </p>
         {{#if importing}}
           <div class ='tale-compose-progressbar'>
             {{ember-progress-bar progress=progress options=(hash strokeWidth=4 color=barColor trailColor= "#a5a4a4")}}

--- a/app/components/dashboard/compose/left-panel/template.hbs
+++ b/app/components/dashboard/compose/left-panel/template.hbs
@@ -1,34 +1,34 @@
 <div class="wt panel manage composer">
-    <div class="wt paddleboard">
-        <h2>
-            <i class="fas fa-edit left"></i> Compose
-            <span class="subtitle">Create a new Tale by pairing a compute environment with a dataset</span>
-            <a href="https://wholetale.readthedocs.io/users_guide/compose.html">
-              <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
-            </a>
-        </h2>
-    </div>
-    <div class="ui segment rounded-bottom composer-container">
-        {{#if launchingInstance}}
-            {{#if importing}}
-            <div style="display: inline">
-                <div class="creating-tale-message">
-                    <div class="progress-area">
-                        <p class ="publishing-status-message">{{message}}</p>
-                    </div>
-                </div>
-                <div class ='tale-import-progressbar'>
-                    {{ember-progress-bar progress=progress options=(hash strokeWidth=4 color=barColor trailColor= "#a5a4a4")}}
-                </div>
-            </div>
-            {{else}}
-                <div style="display: inline">
-                    <div class="creating-tale-message">
-                        {{message}}
-                    <div class="centered"><i class="fa fa-4x fa-circle-notch fa-spin" aria-hidden="true"></i></div>
-                </div>
-            </div>
-            {{/if}}
+  <div class="wt paddleboard">
+    <h2>
+      <i class="fas fa-edit left">
+      </i>
+        Compose
+      <span class="subtitle">
+        Create a new Tale by pairing a compute environment with a dataset
+      </span>
+      <a href="https://wholetale.readthedocs.io/users_guide/compose.html">
+        <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
+      </a>
+    </h2>
+  </div>
+    
+  <div class="ui segment rounded-bottom composer-container">
+    {{#if launchingInstance}}
+      <div class="compose-status">
+          <p class ="compose-status-message">
+            {{message}}
+          </p>
+        {{#if importing}}
+          <div class ='tale-compose-progressbar'>
+            {{ember-progress-bar progress=progress options=(hash strokeWidth=4 color=barColor trailColor= "#a5a4a4")}}
+          </div>
+        {{else}}
+          <div class="tale-compose-loader">
+            <i class="fa fa-4x fa-circle-notch fa-spin"></i>
+          </div>
+        {{/if}}
+      </div>
         {{else}}
             {{partial "forms/new-tale-input"}}
             <div class="ui secondary menu">

--- a/app/components/dashboard/compose/left-panel/template.hbs
+++ b/app/components/dashboard/compose/left-panel/template.hbs
@@ -34,7 +34,7 @@
             <div class="ui secondary menu">
                 <div style="text-align: center">
                     <button class="{{if (or invalidNewTale launchingTale) 'disabled'}} ui big icon button {{if invalidNewTale 'grey'}} {{unless invalidNewTale 'blue'}}"
-                            {{action "createTale"}}>
+                            {{action "onNewTaleClick"}}>
                         Launch New Tale
                     </button>
                 </div>

--- a/app/components/dashboard/compose/left-panel/template.hbs
+++ b/app/components/dashboard/compose/left-panel/template.hbs
@@ -10,12 +10,25 @@
     </div>
     <div class="ui segment rounded-bottom composer-container">
         {{#if launchingInstance}}
+            {{#if importing}}
             <div style="display: inline">
                 <div class="creating-tale-message">
-                    {{message}}
+                    <div class="progress-area">
+                        <p class ="publishing-status-message">{{message}}</p>
+                    </div>
+                </div>
+                <div class ='tale-import-progressbar'>
+                    {{ember-progress-bar progress=progress options=(hash strokeWidth=4 color=barColor trailColor= "#a5a4a4")}}
+                </div>
+            </div>
+            {{else}}
+                <div style="display: inline">
+                    <div class="creating-tale-message">
+                        {{message}}
                     <div class="centered"><i class="fa fa-4x fa-circle-notch fa-spin" aria-hidden="true"></i></div>
                 </div>
             </div>
+            {{/if}}
         {{else}}
             {{partial "forms/new-tale-input"}}
             <div class="ui secondary menu">
@@ -27,5 +40,21 @@
                 </div>
             </div>
         {{/if}}
+    </div>
+</div>
+
+<div class="ui compose-error modal" style="display: none">
+    <div class="header">
+        Error Creating Tale
+    </div>
+    <div class="image content">
+        <div class="description">
+            <p>{{errorMessage}}</p>
+        </div>
+    </div>
+    <div class="actions">
+        <div class="ui black deny button" {{action 'closeErrorModal'}}>
+            Close
+        </div>
     </div>
 </div>

--- a/app/components/dashboard/compose/left-panel/template.hbs
+++ b/app/components/dashboard/compose/left-panel/template.hbs
@@ -16,9 +16,9 @@
   <div class="ui segment rounded-bottom composer-container">
     {{#if launchingInstance}}
       <div class="compose-status">
-          <p class ="compose-status-message">
+          <h1 class ="compose-status-message">
             {{message}}
-          </p>
+          </h1>
         {{#if importing}}
           <div class ='tale-compose-progressbar'>
             {{ember-progress-bar progress=progress options=(hash strokeWidth=4 color=barColor trailColor= "#a5a4a4")}}

--- a/app/components/dashboard/compose/right-panel/component.js
+++ b/app/components/dashboard/compose/right-panel/component.js
@@ -1,17 +1,30 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
-export default Ember.Component.extend({
-  classNameBindings: ['showUpperPanel', 'showLowerPanel'],
+export default Component.extend({
+  wtEvents: service(),
+  classNameBindings: ['showUpperPanel', 'showLowerPanel', 'disableLowerRightPanel'],
   showUpperPanel: true,
   showLowerPanel: true,
+  disableLowerRightPanel: false,
 
+  init() {
+    this._super(...arguments);
+    const self = this;
+    let events = self.get('wtEvents').events;
+
+    // Wait for an event that asks for the file browser to be disabled
+    events.on('onDisableRightPanel', function () {
+      self.set('disableLowerRightPanel', true);
+    });
+  },
   actions: {
     dummy: function() {
       //this.sendAction('action');
     },
     onLeftModelChange : function (model) {
       this.sendAction('onLeftModelChange', model); // sends to parent component
-    }
+    },
   }
 
 });

--- a/app/components/dashboard/compose/right-panel/component.js
+++ b/app/components/dashboard/compose/right-panel/component.js
@@ -18,6 +18,14 @@ export default Component.extend({
       self.set('disableLowerRightPanel', true);
     });
   },
+
+
+  willDestroyElement () {
+    this._super(...arguments);
+    let events = this.get('wtEvents').events;
+    events.off('onDisableRightPanel');
+  },
+
   actions: {
     dummy: function() {
       //this.sendAction('action');

--- a/app/components/dashboard/compose/right-panel/component.js
+++ b/app/components/dashboard/compose/right-panel/component.js
@@ -3,10 +3,9 @@ import { inject as service } from '@ember/service';
 
 export default Component.extend({
   wtEvents: service(),
-  classNameBindings: ['showUpperPanel', 'showLowerPanel', 'disableLowerRightPanel'],
+  classNameBindings: ['showUpperPanel', 'showLowerPanel'],
   showUpperPanel: true,
   showLowerPanel: true,
-  disableLowerRightPanel: false,
 
   init() {
     this._super(...arguments);
@@ -15,7 +14,7 @@ export default Component.extend({
 
     // Wait for an event that asks for the file browser to be disabled
     events.on('onDisableRightPanel', function () {
-      self.set('disableLowerRightPanel', true);
+      self.set('showLowerPanel', false);
     });
   },
 

--- a/app/components/dashboard/compose/right-panel/template.hbs
+++ b/app/components/dashboard/compose/right-panel/template.hbs
@@ -1,6 +1,8 @@
 {{#if showUpperPanel}} 
     {{ui/compute-environments models=rightModelTop onLeftModelChange=(action "onLeftModelChange") isComposing=true }}
 {{/if}}
-{{#if showLowerPanel}} 
-    {{ui/files/mini-browser }} 
+{{#if showLowerPanel}}
+  {{#unless disableLowerRightPanel}}
+    {{ui/files/mini-browser}}
+  {{/unless}}
 {{/if}}

--- a/app/components/dashboard/compose/right-panel/template.hbs
+++ b/app/components/dashboard/compose/right-panel/template.hbs
@@ -2,7 +2,5 @@
     {{ui/compute-environments models=rightModelTop onLeftModelChange=(action "onLeftModelChange") isComposing=true }}
 {{/if}}
 {{#if showLowerPanel}}
-  {{#unless disableLowerRightPanel}}
     {{ui/files/mini-browser}}
-  {{/unless}}
 {{/if}}

--- a/app/components/ui/compute-environments/component.js
+++ b/app/components/ui/compute-environments/component.js
@@ -57,7 +57,15 @@ export default Component.extend({
     } else {
       updater(models);
     }
+
+    let events = this.get('wtEvents').events;
+    events.on('selectEnvironmentByName', function (environmentName) {
+      component.send('selectEnvironmentFromName', environmentName);
+    });
+
   },
+
+
   didRender() {},
   didUpdate() {},
 
@@ -172,7 +180,8 @@ export default Component.extend({
     },
     selectEnvironment(model, index) {
       let component = this;
-      if (this.get('isComposing')) {
+
+      if (component.get('isComposing')) {
         component.set('selectedEnvironment', model);
         component.set('selectedMenuIndex', index);
         component.get('wtEvents').events.selectEnvironment(this.get('selectedEnvironment'));
@@ -180,12 +189,39 @@ export default Component.extend({
         component.get('router').transitionTo('manage.view', model.get('id'));
       }
     },
+
+    /**
+     * Given an environment name, select it in the widget.
+     * 
+     * Iterates over the model (environments), finds the one that matches
+     * the environmentName parameter, and then selects it.
+     * @method selectEnvironmentFromName
+     * @param environmentName {String} 
+    */
+    selectEnvironmentFromName(environmentName) {
+      let component = this;
+      let models = component.get('models')
+
+      // We want to know what the index of the image is in the list. Track the position with i
+      let i = 0;
+      models.forEach(model => {
+        let name = model.get('name');
+        if (name.toLowerCase() == environmentName.toLowerCase()) {
+          component.send('selectEnvironment', model, i)
+        }
+        i++;
+      });
+    },
+    /**
+     * De-selects any selected environment.
+     * 
+     * @method deselectEnvironment
+    */
     deselectEnvironment() {
       let component = this;
       component.set('selectedEnvironment', Object.create({}));
       component.set('selectedMenuIndex', -1);
       component.get('wtEvents').events.selectEnvironment(this.get('selectedEnvironment'));
-      // component.get('router')
       component.get('router').transitionTo('manage.index');
     }
   }

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -5,6 +5,7 @@ export default DS.Model.extend({
   _modelType: DS.attr('string'),
   created: DS.attr('date'),
   interval: DS.attr('number'),
+  log: DS.attr('string'),
   parentId: DS.attr('string'),
   progress: DS.attr(),
   public: DS.attr('boolean'),

--- a/app/routes/compose/index.js
+++ b/app/routes/compose/index.js
@@ -1,19 +1,19 @@
-import Ember from 'ember';
-
 import AuthenticateRoute from 'wholetale/routes/authenticate';
+import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 
 export default AuthenticateRoute.extend({
-  internalState: Ember.inject.service(),
+  internalState: service(),
+  // Optional query parameters used when importing a dataset/Tale
   queryParams:{
-      data_location: {
-          refreshModel:true},
-      data_title: {
-          refreshModel:true},
-      data_api: {
-          refreshModel:true},
-      environment: {
-          refreshModel:true}
+    // The URI of a package or Tale that is going to be imported
+    uri: {refreshModel:true},
+    // An optional title of the dataset or Tale
+    name: {refreshModel:true},
+    // An optional API URL that can be used to access information about the dataset
+    api: {refreshModel:true},
+    // An optional environment name
+    environment: {refreshModel:true}
     },
 
   model(params) {

--- a/app/routes/compose/index.js
+++ b/app/routes/compose/index.js
@@ -5,8 +5,8 @@ import RSVP from 'rsvp';
 
 export default AuthenticateRoute.extend({
   internalState: Ember.inject.service(),
-
-  model() {
+  queryParams:{data_source: {refreshModel:true}},
+  model(params) {
     let state = this.get('internalState');
     let thisUserID = this.get('userAuth').getCurrentUserID();
     let data = this.get('store').query('folder', {
@@ -58,7 +58,8 @@ export default AuthenticateRoute.extend({
         }
       }),
       dataRegistered: registered,
-      allData: registered
+      allData: registered,
+      queryParams: params
     });
   }
 });

--- a/app/routes/compose/index.js
+++ b/app/routes/compose/index.js
@@ -12,6 +12,8 @@ export default AuthenticateRoute.extend({
           refreshModel:true},
       data_api: {
           refreshModel:true},
+      environment: {
+          refreshModel:true}
     },
 
   model(params) {

--- a/app/routes/compose/index.js
+++ b/app/routes/compose/index.js
@@ -9,7 +9,9 @@ export default AuthenticateRoute.extend({
       data_location: {
           refreshModel:true},
       data_provider: {
-          refreshModel:true}
+          refreshModel:true},
+      data_api: {
+          refreshModel:true},
     },
 
   model(params) {

--- a/app/routes/compose/index.js
+++ b/app/routes/compose/index.js
@@ -5,7 +5,13 @@ import RSVP from 'rsvp';
 
 export default AuthenticateRoute.extend({
   internalState: Ember.inject.service(),
-  queryParams:{data_source: {refreshModel:true}},
+  queryParams:{
+      data_location: {
+          refreshModel:true},
+      data_provider: {
+          refreshModel:true}
+    },
+
   model(params) {
     let state = this.get('internalState');
     let thisUserID = this.get('userAuth').getCurrentUserID();

--- a/app/routes/compose/index.js
+++ b/app/routes/compose/index.js
@@ -8,7 +8,7 @@ export default AuthenticateRoute.extend({
   queryParams:{
       data_location: {
           refreshModel:true},
-      data_provider: {
+      data_title: {
           refreshModel:true},
       data_api: {
           refreshModel:true},

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -66,6 +66,7 @@ export default Service.extend({
 
   /**
    * Posts a Tale, using the query parameters specified in the API ...
+   * @method postTale
    * @param httpCommand
    * @param taleID
    * @param imageId
@@ -143,15 +144,16 @@ export default Service.extend({
   },
 
   /**
-   * Creates a Tale from a dataset.
-   * @param imageId The ID of the image used for the Tale
-   * @param identifier The doi/identifier of the data package
-   * @param spawn Bool on whether to spawn the instance
-   * @param lookupKwargs Optional arguments
-   * @param taleKwargs Optional arguments
-   * @param success Callback function that is called on success
-   * @param fail Callback function that is called on fail
-   */
+  * Creates a Tale from a dataset.
+  * @method taleFromDataset
+  * @param imageId The ID of the image used for the Tale
+  * @param identifier The doi/identifier of the data package
+  * @param spawn Bool on whether to spawn the instance
+  * @param lookupKwargs Optional arguments
+  * @param taleKwargs Optional arguments
+  * @param success Callback function that is called on success
+  * @param fail Callback function that is called on fail
+  */
   taleFromDataset: function (imageId,
     identifier, 
     spawn,
@@ -262,12 +264,13 @@ export default Service.extend({
     client.send();
   },
 
-    /**
-   * Queries the job result endpoint.
-   * @param jobId The ID of the job whose status is wanted
-   * @param success Function that is called on success
-   * @param fail Function that is called when the call fails
-   */
+  /**
+  * Queries the job result endpoint.
+  * @method getFinalJobStatus
+  * @param jobId The ID of the job whose status is wanted
+  * @param success Function that is called on success
+  * @param fail Function that is called when the call fails
+  */
   getFinalJobStatus(jobId, success, fail) {
     var token = this.get('tokenHandler').getWholeTaleAuthToken();
     var url = config.apiUrl + '/job/' + jobId + '/result';

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -65,20 +65,20 @@ export default Service.extend({
 
 
   /**
-   * Posts a Tale, using the query parameters specified in the API ...
-   * @method postTale
-   * @param httpCommand
-   * @param taleID
-   * @param imageId
-   * @param folderId
-   * @param instanceId
-   * @param title
-   * @param description
-   * @param isPublic
-   * @param configuration
-   * @param success
-   * @param fail
-   */
+  * Posts a Tale, using the query parameters specified in the API ...
+  * @method postTale
+  * @param httpCommand
+  * @param taleID
+  * @param imageId
+  * @param folderId
+  * @param instanceId
+  * @param title
+  * @param description
+  * @param isPublic
+  * @param configuration
+  * @param success
+  * @param fail
+  */
   postTale: function (httpCommand, taleID, imageId, folderId, instanceId, title, description, isPublic, configuration, success, fail) {
     var token = this.get('tokenHandler').getWholeTaleAuthToken();
     var url = config.apiUrl + '/tale/';

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -149,6 +149,8 @@ export default Service.extend({
    * @param spawn Bool on whether to spawn the instance
    * @param lookupKwargs Optional arguments
    * @param taleKwargs Optional arguments
+   * @param success Callback function that is called on success
+   * @param fail Callback function that is called on fail
    */
   taleFromDataset: function (imageId,
     identifier, 

--- a/app/services/wt-events.js
+++ b/app/services/wt-events.js
@@ -5,14 +5,38 @@ import Service from '@ember/service';
 export default Service.extend({
   events: function() {
     let Events = EmberObject.extend(Evented, {
+
+      /**
+      * @method select
+      */
       select(allSelected) {
         this.trigger('select', allSelected);
       },
 
+      /**
+      * Lets the environment widget know to select an environment by model
+      *
+      * @method selectEnvironment
+      */
       selectEnvironment(environment) {
         this.trigger('selectEnvironment', environment);
       },
 
+      /**
+      * Lets the environment widget know to select an environment by 
+      * name.
+      * @method selectEnvironmentByName
+      * @param {String} environmentName The name of the environment
+      */
+      selectEnvironmentByName(environmentName) {
+        this.trigger('selectEnvironmentByName', environmentName);
+      },
+
+      /**
+      * Lets the right panel know to disable part of the right panel
+      *
+      * @method disableRightPanel
+      */
       disableRightPanel() {
         this.trigger('onDisableRightPanel');
       }

--- a/app/services/wt-events.js
+++ b/app/services/wt-events.js
@@ -11,7 +11,12 @@ export default Service.extend({
 
       selectEnvironment(environment) {
         this.trigger('selectEnvironment', environment);
+      },
+
+      disableRightPanel() {
+        this.trigger('onDisableRightPanel');
       }
+
     });
     return Events.create();
   }()

--- a/app/styles/modals.scss
+++ b/app/styles/modals.scss
@@ -1,21 +1,23 @@
+/* Override Semantic craziness */
+.ui.legacy.modal,
+.ui.legacy.page.dimmer > .ui.modal {
+  top: 20px!important;
+  left: 0!important;
+}
+
 .ui.modal {
-    position: fixed;
-    top:    0;
-    left:   0;
-    right:  0;
-    bottom: 0;
-    margin: auto !important;
-  }
-  
+  position: fixed;
+  top:    20px;
+  left:   0;
+  right:  0;
+  margin: auto !important;
+
   .newfolder,
   .delete-modal,
   .ui.dataone.modal,
   .warning-modal,
   .ui.compose-error.modal {
     height: 200px;
-    top:    0;
-    left:   0;
-    bottom: 0;
   
     .header {
       .close.icon {
@@ -30,6 +32,7 @@
       color: black;
     }
   }
+}
 
 .ui.compose-error.modal .description {
   width: 100%;

--- a/app/styles/modals.scss
+++ b/app/styles/modals.scss
@@ -10,8 +10,12 @@
   .newfolder,
   .delete-modal,
   .ui.dataone.modal,
-  .warning-modal {
+  .warning-modal,
+  .ui.compose-error.modal {
     height: 200px;
+    top:    0;
+    left:   0;
+    bottom: 0;
   
     .header {
       .close.icon {
@@ -26,7 +30,11 @@
       color: black;
     }
   }
-  
+
+.ui.compose-error.modal .description {
+  width: 100%;
+}
+
 .destinate-folder {
     left: 0 !important;
     margin: auto !important;

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -28,6 +28,9 @@ $desktop: "only screen and (min-width:#{$tablet-screen})";
 $landscape: "only screen and (orientation: landscape)";
 $portrait: "only screen and (orientation: portrait)";
 
+// How far down from the top the compose message is
+$compose-message-top: 0vh;
+
 @import './ember-burger-menu/variables';
 @import './ember-burger-menu/animations/slide';
 @import './ember-burger-menu/animations/menu-item/push';
@@ -41,37 +44,35 @@ body {
   background: #d6e1e8;
 }
 
-// loader starts
-.loading-pane {
-  height: 100%;
-  width: 100%;
-  background: #f3f3f3 center center;
-  background-size: cover;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-.creating-tale-message {
-  position: absolute;
-  z-index: 100;
-  left: calc(((100% * 11) / 16) / 2 + 45px);
-  top: 14rem;
-
-  .centered {
-    text-align: center;
-    margin-top: 1em;
-  }
+.compose-status {
+  position: inherit;
+  height:100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
-.tale-import-progressbar {
-    position: absolute;
-    top: 10rem;
-    width:50%;
-    left: calc(((50% * 11) / 16) / 2 + 35px);
-
+.compose-status-message {
+  position: relative;
+  top:0px;
+  line-height: 20px;
+  color: black;
+  font-weight: bold;
+  font-size: 2em;
 }
 
-// loader ends
+.tale-compose-progressbar {
+  position: relative;
+  top: calc(#{$compose-message-top} + 2vh);
+  width: 50%;
+}
+
+// If we aren't importing a dataset
+.tale-compose-loader {
+  position: relative;
+  top: calc(#{$compose-message-top} + 2vh);
+}
 
 /* Navigation - Top Nav */
 

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -55,16 +55,13 @@ body {
 
 .compose-status-message {
   position: relative;
-  top:20%;
+  top:calc(#{$compose-message-top});
   line-height: 20px;
-  color: black;
-  font-weight: bold;
-  font-size: 2em;
 }
 
 .tale-compose-progressbar {
   position: relative;
-  top: calc(#{$compose-message-top});
+  top: calc(#{$compose-message-top+5%});
   width: 50%;
 }
 

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -29,7 +29,7 @@ $landscape: "only screen and (orientation: landscape)";
 $portrait: "only screen and (orientation: portrait)";
 
 // How far down from the top the compose message is
-$compose-message-top: 0vh;
+$compose-message-top: 30%;
 
 @import './ember-burger-menu/variables';
 @import './ember-burger-menu/animations/slide';
@@ -49,13 +49,13 @@ body {
   height:100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+
   align-items: center;
 }
 
 .compose-status-message {
   position: relative;
-  top:0px;
+  top:20%;
   line-height: 20px;
   color: black;
   font-weight: bold;
@@ -64,14 +64,14 @@ body {
 
 .tale-compose-progressbar {
   position: relative;
-  top: calc(#{$compose-message-top} + 2vh);
+  top: calc(#{$compose-message-top});
   width: 50%;
 }
 
 // If we aren't importing a dataset
 .tale-compose-loader {
   position: relative;
-  top: calc(#{$compose-message-top} + 2vh);
+  top: calc(#{$compose-message-top});
 }
 
 /* Navigation - Top Nav */

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -57,6 +57,7 @@ body {
   position: relative;
   top:calc(#{$compose-message-top});
   line-height: 20px;
+  font-size: 1.5em;
 }
 
 .tale-compose-progressbar {

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -55,13 +55,22 @@ body {
   position: absolute;
   z-index: 100;
   left: calc(((100% * 11) / 16) / 2 + 45px);
-  top: 2rem;
+  top: 14rem;
 
   .centered {
     text-align: center;
     margin-top: 1em;
   }
 }
+
+.tale-import-progressbar {
+    position: absolute;
+    top: 10rem;
+    width:50%;
+    left: calc(((50% * 11) / 16) / 2 + 35px);
+
+}
+
 // loader ends
 
 /* Navigation - Top Nav */
@@ -1089,3 +1098,4 @@ wt.panel .wt.paddleboard.header i {
     display: none;
   }
 }
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8759,6 +8759,18 @@
         }
       }
     },
+    "ember-progress-bar": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-progress-bar/-/ember-progress-bar-1.0.0.tgz",
+      "integrity": "sha512-p06vzp7kCIa63YIUXnY+oQ+ojE8XzIRVyhbFeDVbImeDJM1yc/bl3dD+BEerppx7qg1bhf8A8YVclIERk8NPng==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "1.2.0",
+        "ember-cli-babel": "6.12.0",
+        "ember-cli-htmlbars": "2.0.3",
+        "progressbar.js": "1.0.1"
+      }
+    },
     "ember-promise-utils": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ember-promise-utils/-/ember-promise-utils-0.1.1.tgz",
@@ -17255,6 +17267,15 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
+    "progressbar.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/progressbar.js/-/progressbar.js-1.0.1.tgz",
+      "integrity": "sha1-9/v8GVJA/guzL2972y5/9ADqcfk=",
+      "dev": true,
+      "requires": {
+        "shifty": "1.5.4"
+      }
+    },
     "promise-map-series": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
@@ -18451,6 +18472,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
+    },
+    "shifty": {
+      "version": "1.5.4",
+      "resolved": "http://registry.npmjs.org/shifty/-/shifty-1.5.4.tgz",
+      "integrity": "sha1-1DYvyRTdKA3fblIr5AiyEgMgg0Y=",
       "dev": true
     },
     "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ember-modal-dialog": "^3.0.0-beta.0",
     "ember-moment": "^7.7.0",
     "ember-oauth2": "^2.0.4-beta",
+    "ember-progress-bar": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-route-action-helper": "^2.0.6",
     "ember-simple-auth": "^1.6.0",


### PR DESCRIPTION
# Summary

This PR includes changes needed for importing a dataset from a third party. Most of the code changes are in the left panel of the compose page, but smaller changes are sprinkled across the route, api-call file, and the stylesheets.

This PR addresses issues

#286 
#271 
#282
#288
#289
#290 

# Route Changes

These changes are located in `app/routes/compose/index.js`. The route is the _thing_ that handles a user landing on a page. I added some fields for query parameters, so that we can save information, for example the selected environment, doi/location of the dataset, dataset name, etc. You can see how these are grabbed in the left-panel component by searching for `this.get('model').queryParams.data_location`.

# Api Call Changes

These changes are located in `app/services/api-call.js`.
A nice way to keep interactions with the backend API tidy is by defining methods that contact each point. This file is where those methods go. Ideally these would be unit tested so that we can check if anything in the UI will break if the backend API changes.

In [this PR](https://github.com/whole-tale/girder_wholetale/pull/173) @Xarthisius added two additional points: /tale/import and /job/result. Since I'd like to use these in the UI, I added two methods to api-call.js. Each method follows the form of the other methods, taking a success and error callback.


# Compose Page Changes

## Support Handling Errors
We historically haven't been handling errors during Tale creation. If anything wrong happens, we would just redirect the user back to the blank compose page.

Line 46 in the left-panel template is where I defined the error modal. This follows the pattern we've been using with other small modal dialogs (see tale-browser, status.hbs, etc). Since this modal is semanticui, we can open it with jquery (not ideal-but the alternative of manually managing active div tags can get very messy). You can see the cases where it opens by searching for `component.send('openErrorModal')` in the component. The reason we're sending is because `openErrorModal` is an action. 

When the user closes the modal, we reset relevant information and direct them back to the compose page. **Note that the Tale is still created, but not launched**

This is relevant to issue #282 

Larger modals are created in separate files, you can find examples of this by searching the project for `{{#ui-modal`. This method has been depreciated, and large modals should use `modal-dialog`. We use the pattern described [here](https://dockyard.com/blog/2015/06/08/a-clean-pattern-for-modal-dialogs).

<img width="1678" alt="screen shot 2018-11-15 at 1 48 20 pm" src="https://user-images.githubusercontent.com/9289652/48583891-35a19b00-e8dd-11e8-8be8-4e4169988ae7.png">


## Add the Progressbar

In the left-panel template I added a progressbar to show status of tale creation. This is _only_ shown during tale/dataset importing. You can walk through the if statements to verify. The old/default behavior is used when the user composes a Tale "normally" (no dataset importing).


<img width="1665" alt="screen shot 2018-11-15 at 1 49 18 pm" src="https://user-images.githubusercontent.com/9289652/48583922-4a7e2e80-e8dd-11e8-9d02-0b534576e0ea.png">


## Tell Backend to Create Tale from Dataset

The method in api-call.js for importing a dataset is used in `createTaleFromDataset`. We send the minimum: The environment and dataset location. We also pass in success and fail callback methods to handle the response.

## Progressbar Updating

This is probably the most complicated portion of the code changes. Progressbar updating is started when the success callback method for tale creation executes. The callback just calls, `trackTaleImport`, which handles the update.

This method mimics the existing tale creation code by polling the job endpoint (the existing code polls the instance endpoint).  There are a number of status codes that the job can have, and we use them to check the state of the tale and act accordingly. The calls to `component.get('apiCall').getFinalJobStatus` have inline functions for the callbacks.

# To-Do

## Pass Tale Name to Backend - Done in 364dabc

I need to pass the tale name to the import endpont since we have it

## Hide the File Browser - Done in 92fc1d8
Letting the user select files needs some work on the backend-see the issue in gwvolman. Until then, we're hiding the file browser.

The left and right panel don't know about eachother. The right panel needs to know if we should hide the broswer, and the left panel has that knowledge. 

I added an event that the right panel listens on, and the left panel fires it if necessary. 

## Auto select environments based on queryparams -Done in 5fb725e

Refer to issue #289 

## Styling - Done in 80f85ee

There are a few small styling changes that need to be made (center alignment, font size)

This screenshot can help with seeing the div structure. The pink color is the flexbox cxontainer, and the tomato colored div+progressbar are the children.

<img width="871" alt="screen shot 2018-11-16 at 11 56 01 am" src="https://user-images.githubusercontent.com/9289652/48645108-837bd900-e999-11e8-8c09-20f6207eaee6.png">


Video of the changes in action.
http://recordit.co/8Ms4b5iI4f

