### PR TITLE
Added size and doi fields to dataMap

### DIFF
--- a/app/components/ui/files/registration-modal/component.js
+++ b/app/components/ui/files/registration-modal/component.js
@@ -164,7 +164,9 @@ export default Ember.Component.extend({
             let dataMap = JSON.stringify([{
                 name: this.name,
                 dataId: this.dataId,
-                repository: this.repository
+                repository: this.repository,
+                doi: this.doi,
+                size: this.size
             }]);
 
             let baseUrl=this.get('prodUrl');


### PR DESCRIPTION
With recent Girder updates, data registration is failing because the size and doi fields are missing from the dataMap.  This PR simply adds these fields to the registration-modal component.


Error from Girder logs:
```
[2018-11-23 11:36:12,108] ERROR: 500 Error
Traceback (most recent call last):
  File "/girder/girder/api/rest.py", line 630, in endpointDecorator
    val = fun(self, path, params)
  File "/girder/girder/api/rest.py", line 1224, in POST
    return self.handleRoute(method, path, params)
  File "/girder/girder/api/rest.py", line 967, in handleRoute
    val = handler(**kwargs)
  File "/girder/girder/api/access.py", line 63, in wrapped
    return fun(*args, **kwargs)
  File "/girder/girder/api/describe.py", line 709, in wrapped
    return fun(*args, **kwargs)
  File "/girder/plugins/wholetale/server/rest/dataset.py", line 226, in importData
    dataMaps = DataMap.fromList(dataMap)
  File "/girder/plugins/wholetale/server/lib/data_map.py", line 85, in fromList
    return [DataMap.fromDict(x) for x in d]
  File "/girder/plugins/wholetale/server/lib/data_map.py", line 85, in <listcomp>
    return [DataMap.fromDict(x) for x in d]
  File "/girder/plugins/wholetale/server/lib/data_map.py", line 80, in fromDict
    return DataMap(d['dataId'], d['size'], repository=d['repository'], doi=d['doi'],
KeyError: 'size'
Additional info:
  Request URL: POST https://girder.dev.wholetale.org/api/v1/dataset/register
  Query string: parentType=user&parentId=59fb6165f7e8790001da4e8b&public=false
  Remote IP: 10.0.0.2
```