### PR TITLE
Preserve return route for non-logged-in users

### DIFF
--- a/app/routes/authenticate.js
+++ b/app/routes/authenticate.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
+import { inject as service } from '@ember/service';
 
 export default Ember.Route.extend({
   tokenHandler: Ember.inject.service('token-handler'),
   userAuth: Ember.inject.service('user-auth'),
+  routerService: service('-routing'),
   currentUser: null,
   token: null,
 
@@ -28,7 +30,14 @@ export default Ember.Route.extend({
           this.get("tokenHandler").releaseWholeTaleCookie();
           this.get("userAuth").resetCurrentUser();
           router.set('currentUser', null);
-          router.transitionTo('login');
+          let returnRoute = this.routerService.router.url;
+          
+          // Prevent nexting of multiple "rd" parameters inside each other
+          if (returnRoute.indexOf("?rd=") !== -1) {
+            router.transitionTo('login');
+          } else {
+            router.transitionTo('login', { queryParams: { rd: encodeURIComponent(returnRoute) }});
+          }
           return null;
         } else {
           //   console.log("User is not null!!!");

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -15,9 +15,15 @@ export default Ember.Route.extend({
     var slashes = http.concat("//");
     var ishttp = (location.port === '') || (location.port === 80) || (location.port === 443);
     var host = slashes.concat(window.location.hostname) + (ishttp? "": ':'+location.port);
-    console.log("Route: ", this.routerService);
-    var pathSuffix = params.rd || "";
-    let url = config.apiUrl + '/oauth/provider?redirect=' + host + pathSuffix + "%3Ftoken%3D%7BgirderToken%7D";
+    var pathSuffix = decodeURIComponent(params.rd) || "";
+    // Append to query string if on exists, otherwise add one
+    if (pathSuffix.indexOf("?") !== -1) {
+      pathSuffix += "&token={girderToken}"
+    } else {
+      pathSuffix += "?token={girderToken}"
+    }
+    var redirectUrl = host + pathSuffix;
+    let url = config.apiUrl + '/oauth/provider?redirect=' + encodeURIComponent(redirectUrl);
 
     return Ember.$.getJSON(url);
   }

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,14 +1,23 @@
 import Ember from 'ember';
+import { inject as service } from '@ember/service';
 import config from '../config/environment';
 
 export default Ember.Route.extend({
+  queryParams: {
+    rd: {
+      refreshModel: true
+    }
+  },
+  routerService: service('-routing'),
   model: function(params) {
     // console.log("In login route");
     var http = location.protocol;
     var slashes = http.concat("//");
     var ishttp = (location.port === '') || (location.port === 80) || (location.port === 443);
     var host = slashes.concat(window.location.hostname) + (ishttp? "": ':'+location.port);
-    let url = config.apiUrl + '/oauth/provider?redirect=' + host + "%3Ftoken%3D%7BgirderToken%7D";
+    console.log("Route: ", this.routerService);
+    var pathSuffix = params.rd || "";
+    let url = config.apiUrl + '/oauth/provider?redirect=' + host + pathSuffix + "%3Ftoken%3D%7BgirderToken%7D";
 
     return Ember.$.getJSON(url);
   }


### PR DESCRIPTION
# Problem
When navigating to a view that requires authentication, the user is redirected to login without preserving the route they originally requested. OAuth navigates us away from the dashboard, losing all context of historically visited routes.

# Approach
I've added a bit of logic into the `AuthenticateRoute` to handle saving the originally-requested route into the `rd` query string parameter (e.g. `/login?rd=%2Fsome%2Furl%2Fencoded%2Fpath`). This way, the login route can pass this into its call to Girder's `/oauth/provider` endpoint for Girder to properly redirect us back to the requested path.

# How to Test
1. Login and navigate to one of your running instances in the dashboard - save this URL for testing (e.g. `https://dashboard.dev.wholetale.org/run/someuniquegirderid`) 
2. Open an Incognito Window and navigate to the same URL you saved above
    * You should be redirected to the `/login` route
    * The route you originally requested should be preserved in the `rd` query string parameter
3. Click the Login button to log into the WholeTale Dashboard
    * You should be logged in to the dashboard, as expected
    * You should be automatically navigated to the route specified by `rd ` previously


Caveats:
* I was unable to figure out how to strip the `?token=` query string parameter after successful authentication. This token should not be needed, as Girder's OAuth should be setting the GirderToken as a cookie, but perhaps this is not the case because `girder` and `dashboard` are served from different domains?