### PR TITLE
Remove the publishing & edit paddleboard

### DIFF
--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -12,6 +12,7 @@
             {{/if}}
         </h2>
     </div>
+    {{!-- DEVNOTE: This should be enabled when we're ready to publish Tales
     {{#unless noInstanceSelected}}
         <div class="wt paddleboard tall header">
             <div class="ui bordlerless menu">
@@ -42,7 +43,7 @@
                 </div>
             </div>
         </div>
-    {{/unless}}
+    {{/unless}} --}}
     {{!-- {{#if (eq internalState.currentInstanceId model._id)}} --}}
     {{#if hasSelectedTaleInstance}}
       {{#if (not-eq model.status 0)}}


### PR DESCRIPTION
This PR removes the publishing and edit tale paddleboard at the top of the run page. I commented the code out so that we can un-comment it at a later time when we're ready for it in production.

Fix for #311 