### PR TITLE
First-pass at detection/correction of internal-state desync

### DIFF
--- a/app/services/internal-state.js
+++ b/app/services/internal-state.js
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import { A } from '@ember/array';
 
@@ -7,6 +8,7 @@ import { A } from '@ember/array';
 
 export default Service.extend({
   isAuthenticated: true,
+  store: service(),
   currentInstanceId: computed({
     get() {
       return (localStorage.currentInstanceId && localStorage.currentInstanceId !== 'undefined') ? JSON.parse(localStorage.currentInstanceId) : undefined;
@@ -30,7 +32,23 @@ export default Service.extend({
   },
 
   getCurrentFolderID: function () {
-    return localStorage.currentFolderID;
+    let currentFolderID = localStorage.currentFolderID;
+    
+    // Skip checking falsey ID strings
+    if (typeof(currentFolderID) !== "undefined" && currentFolderID) {
+      this.store.findRecord('folder', currentFolderID).then(function(result) {
+        // folder exists - effectively a noop
+        // NOTE: after first lookup, this result is cached in the store
+      }).catch(function(error) {
+        //console.log(`Failed to fetch current folder (${currentFolderID}):`, error);
+        // Set currentFolderID to "undefined" and refresh the page
+        localStorage.removeItem("currentFolderID");
+        currentFolderID = undefined;
+        window.location.reload(true);
+      });
+    }
+    
+    return currentFolderID;
   },
 
   setCurrentFolderName: function (val) {


### PR DESCRIPTION
# Problem
Fixes #268

The current UI stores/recalls server data in localStorage without validating it. This can lead to de-synchronization when operating in multiple tabs. For example, if a user has multiple tabs open and deletes the folder that another tab has loaded, the user can be stuck in a blue screen (even after refresh) until they manually navigate to the `/browse` view.

NOTE: as long as the user does not refresh the page, their view remains intact, as the browser / store will keep a cache of most of the stale server data

# Approach
This quick-fix will detect when the user has refreshed with a bad state, clear the bad state, and force another refresh to load them with a clean state.

Ideally, the right way to do this would be to return a `Promise` that we can resolve asynchronously and have the downstream components handle this Promise accordingly. I tried returning a Promise here, but I had some difficulty getting things working that way. It is possible that I messed up the syntax there, but since `currentFolderID` is used in several views I was hesitant to change how it works under the covers without understanding how wide-reaching the effects would be.

# Test Case
1. Check out and start up this branch: `ember s`
2. Open a non-incognito browser tab, log into the UI and navigate to the `/manage` view
3. Create a folder (e.g. `test123`) and click down into it
4. Open an incognito browser tab, login to the UI again, and navigate to the `/manage` view
5. In the incognito tab, delete the `test123` folder and close the incognito tab
6. Refresh your non-incognito browser tab
    * You should **not** be stuck on a blue screen
    * You should **not** need to manually refresh the page
    * You should be taken to the `/manage` view of your Home folder
    * NOTE: Your last refresh may take a couple of seconds longer than usual