### PR TITLE
Handle the case when pathSuffix is falsy

### DIFF
--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -15,7 +15,7 @@ export default Ember.Route.extend({
     var slashes = http.concat("//");
     var ishttp = (location.port === '') || (location.port === 80) || (location.port === 443);
     var host = slashes.concat(window.location.hostname) + (ishttp? "": ':'+location.port);
-    var pathSuffix = decodeURIComponent(params.rd) || "";
+    var pathSuffix = decodeURIComponent(params.rd || "");
     var redirectUrl = host;
     // Append return route if one exists, ignore login route
     if (pathSuffix && pathSuffix.indexOf('/login') === -1) {

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -16,13 +16,17 @@ export default Ember.Route.extend({
     var ishttp = (location.port === '') || (location.port === 80) || (location.port === 443);
     var host = slashes.concat(window.location.hostname) + (ishttp? "": ':'+location.port);
     var pathSuffix = decodeURIComponent(params.rd) || "";
-    // Append to query string if on exists, otherwise add one
-    if (pathSuffix.indexOf("?") !== -1) {
-      pathSuffix += "&token={girderToken}"
-    } else {
-      pathSuffix += "?token={girderToken}"
+    var redirectUrl = host;
+    // Append return route if one exists, ignore login route
+    if (pathSuffix && pathSuffix.indexOf('/login') === -1) {
+      redirectUrl += pathSuffix
     }
-    var redirectUrl = host + pathSuffix;
+    // Append to query string if one exists, otherwise add one
+    if (redirectUrl.indexOf("?") !== -1) {
+      redirectUrl += "&token={girderToken}"
+    } else {
+      redirectUrl += "?token={girderToken}"
+    }
     let url = config.apiUrl + '/oauth/provider?redirect=' + encodeURIComponent(redirectUrl);
 
     return Ember.$.getJSON(url);


### PR DESCRIPTION
# Problem
Fixes #329 

Login return route handling is flaky when logging in and out several times

# Approach
Added handling for when return route is `undefined` or falsy. Also, prevent `/login` as the return route, as this would create a cycle.

# Test Case
1. Check out and run this branch: `ember s`
2. Open an incognito tab to http://localhost:4200 and login
3. Logout
4. Login again
    * You should be logged in successfully
    * Your destination URL should **not** contain `undefined`

