### PR TITLE
Handle 400 errors when transitioning to the /run/:id route

### DIFF
--- a/app/routes/run/view.js
+++ b/app/routes/run/view.js
@@ -18,5 +18,20 @@ export default AuthenticateRoute.extend({
       }),
       selected: this.get('store').findRecord('instance', params.instance_id, { reload: true })
     });
+  },
+  actions: {
+    error(error, transition) {
+      // The docs led me to believe that the 'error' object would have a different format...
+      // See https://guides.emberjs.com/v3.1.0/routing/loading-and-error-substates/#toc_the-error-event
+      for (let err of error.errors) {
+        
+        // If we hit a 400 during transition, it is likely that 
+        // currentInstanceId is no longer valid.. Redirect to /browse instead
+        if (err.status === '400') {
+          this.replaceWith('browse');
+          return true;
+        }
+      }
+    }
   }
 });


### PR DESCRIPTION
# Problem
When an instance is shut down, tabs with a reference to that instance ID become invalid. Refreshing the tab yields only a blue screen, and the user must navigate away from a tale-specific context in order to correct this.

Fixes #323 
Fixes #189 
Fixes #185 

# Approach
The idea here is to add subtle error handling to the route transitions using [Ember's `error` substate](https://guides.emberjs.com/v3.1.0/routing/loading-and-error-substates/#toc_the-error-event). We can also optionally add a notification in here somewhere, to let the user know why they ended up on the `/browse` page instead of where they may have been expecting to land.

# How to Test
1. Checkout and run this branch
2. Navigate to the WholeTale Dashboard
3. Manually change the path suffix in the address bar to `/run/ThisIsObviouslyNotARealID`
    * You should be brought to `/browse` page instead