### PR TITLE
Allow user to delete an instance while it is still spawning

### DIFF
--- a/app/components/ui/tale-instances/template.hbs
+++ b/app/components/ui/tale-instances/template.hbs
@@ -24,9 +24,7 @@
               <a class="item {{if (and internalState.currentInstanceId (eq internalState.currentInstanceId instance._id)) 'active'}}" {{action 'transitionToRun' instance index preventDefault=true}}>
                   <img src="{{instance.tale.illustration}}" />
                   <img src="{{instance.tale.icon}}" class="env" />
-                  {{#unless (eq instance.status 0)}}
-                    <i class="times icon" {{action 'openDeleteModal' instance bubbles=false}}></i>
-                  {{/unless}}
+                  <i class="times icon" {{action 'openDeleteModal' instance bubbles=false}}></i>
                   <p>{{truncate-name instance.name}}</p>
                 {{#if (eq instance.status 0)}}
                   <span style="position: absolute; left: 45%; top: 20%; opacity: .7; z-index: 1">


### PR DESCRIPTION
# Problem
Fixes #330 

When a user spawns an instance, very rarely a job can fail and the instance spins indefinitely. In this case, it would be helpful to be able to delete the faulty instance.

# Approach
We currently hide the delete button from tales in a `LAUNCHING` state, but the API does not prevent operating on these objects. If we always show the delete button, the user can reset their state without needing to contact support.

# Test Case
1. Checkout and run this branch
2. Open the WholeTale Dashboard and navigate to `/browse`
3. Choose any Tale from the list on the left and click "Launch"
    * You should see your Instance appear in the "Launched Tales" panel on the right
    * You should see a spinner at the center of the new Instance in the list, indicating that the Instance is "Launching"
    * You should see the Delete (X) icon appears at the top-right of the new Instance in the list at all times
4. Before the Tale finishes spawning (if you see the spinner disappear, you were too late), click the Delete button
    * You should be prompted for confirmation via modal window
5. Confirm deletion of the Tale in the modal
    * You should see the Instance disappear from the "Launched Tales" panel