### PR TITLE
External data tab

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -47,8 +47,12 @@ export default DS.RESTAdapter.extend(buildQueryParamsMixin, {
     if (appendPath) {
       url += "/" + snapshot.adapterOptions.appendPath;
     }
+    let insertPath = _.get(snapshot, 'adapterOptions.insertPath');
+    if (insertPath) {
+      url = url.replace(id, `${insertPath}/${id}`);
+    }
     let queryParams = _.get(snapshot, 'adapterOptions.queryParams');
-    if (queryParams) {
+    if (queryParams) { 
       let q = this.buildQueryParams(queryParams);
       return url + "?" + q;
     }

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -138,18 +138,37 @@ export default DS.RESTAdapter.extend(buildQueryParamsMixin, {
   },
 
   updateRecord(store, type, snapshot) {
+    let data = {};
+    let serializer = store.serializerFor(type.modelName);
+
+    serializer.serializeIntoHash(data, type, snapshot);
+
+    let id = snapshot.id;
+    let url = this.buildURL(type.modelName, id, snapshot, 'updateRecord');
+    
     if (_.get(snapshot, "adapterOptions.copy")) {
-      let data = {};
-      let serializer = store.serializerFor(type.modelName);
-
-      serializer.serializeIntoHash(data, type, snapshot);
-
-      let id = snapshot.id;
-      let url = this.buildURL(type.modelName, id, snapshot, 'updateRecord');
-
       return this.get('authRequest').send(url, {
         method: "POST",
         data: data
+      });
+    }
+
+    // NOTE(Adam): The /dm endpoint does not match what the ember REST adapter expects.
+    //             For example, Ember adapter uses PATCH to update models. And Ember also expects a json body but /dm uses query params. 
+    //             And the endpoint uses /dm/session/{id} instead of /dm/{id}. 
+    //             For these reasons, I must override the Ember adapter and customize the update function for the /dm endpoint.
+    if (type.modelName === 'dm') {
+      url = url.replace(id, `session/${id}`);
+      let q = '';
+      try {
+        q = this.buildQueryParams({dataSet: JSON.stringify(snapshot.record.dataSet)});
+      } catch(e) {
+        throw new Error("could not save dataset back to the session.");
+      }
+      url += '?'+q;
+
+      return this.get('authRequest').send(url, {
+        method: "PUT"
       });
     }
 

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -3,12 +3,14 @@ import { inject as service } from '@ember/service';
 import FullScreenMixin from 'ember-cli-full-screen/mixins/full-screen';
 import config from '../../../../config/environment';
 import { scheduleOnce } from '@ember/runloop';
-import { computed } from '@ember/object';
+import Object, { computed } from '@ember/object';
 import { A } from '@ember/array';
 import { not } from '@ember/object/computed';
 import $ from 'jquery';
 import layout from './template';
 // import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+
+const O = Object.create.bind(Object);
 
 export default Component.extend(FullScreenMixin, {
     layout,
@@ -21,10 +23,13 @@ export default Component.extend(FullScreenMixin, {
     hasSelectedTaleInstance: false,
     displayTaleInstanceMenu: false,
 
-    sessionData: A(),
+    session: O({dataSet:A()}),
 
-    allSelectedItems: computed('sessionData', function() {
-      return A(this.sessionData.concat([]));
+    allSelectedItems: computed('session', function() {
+      return A(this.session.get('dataSet').map(item => {
+        let {itemId, mountPath} = item;
+        return O({id: itemId, name: mountPath.replace(/\//g, '') });
+      }));
     }),
 
     init() {
@@ -155,31 +160,16 @@ export default Component.extend(FullScreenMixin, {
             return true;
         },
         updateSessionData(listOfSelectedItems) {
-          // console.log('updating session data...');
-          // NOTE: Structure of the list looks like this:
-
-          /*
-            [
-              {
-                "id": "59aeb3f246a83d0001ab6777",
-                "name": "us85co.xls",
-                "_modelType": "item"
-              },
-              {
-                "id": "59aeb3f246a83d0001ab6775",
-                "name": "usco2000.xls",
-                "_modelType": "item"
-              },
-              {
-                "id": "59aeb3f246a83d0001ab677b",
-                "name": "datadict2005.html",
-                "_modelType": "item"
-              }
-            ]
-          */
-
-          // do something with selected items here ...
-          
+          let dataSet = listOfSelectedItems.map(item => {
+            let {id, name} = item;
+            return {itemId: id, mountPath: name};
+          });
+          this.session.set('dataSet', dataSet);
+          this.session.save()
+            .then(() => {
+              // TODO(Adam): Somehow refresh the state of the external data tab to reflect the changes made to the session.
+            })
+          ;
       },
       openSelectDataModal() {
           $('.ui.modal.selectdata').modal('show');

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -4,9 +4,11 @@ import FullScreenMixin from 'ember-cli-full-screen/mixins/full-screen';
 import config from '../../../../config/environment';
 import { scheduleOnce } from '@ember/runloop';
 import { computed } from '@ember/object';
+import { A } from '@ember/array';
 import { not } from '@ember/object/computed';
 import $ from 'jquery';
 import layout from './template';
+// import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 export default Component.extend(FullScreenMixin, {
     layout,
@@ -18,6 +20,12 @@ export default Component.extend(FullScreenMixin, {
     wholeTaleHost: config.wholeTaleHost,
     hasSelectedTaleInstance: false,
     displayTaleInstanceMenu: false,
+
+    sessionData: A(),
+
+    allSelectedItems: computed('sessionData', function() {
+      return A(this.sessionData.concat([]));
+    }),
 
     init() {
         this._super(...arguments);
@@ -145,6 +153,36 @@ export default Component.extend(FullScreenMixin, {
 
         denyDelete() {
             return true;
-        }
+        },
+        updateSessionData(listOfSelectedItems) {
+          // console.log('updating session data...');
+          // NOTE: Structure of the list looks like this:
+
+          /*
+            [
+              {
+                "id": "59aeb3f246a83d0001ab6777",
+                "name": "us85co.xls",
+                "_modelType": "item"
+              },
+              {
+                "id": "59aeb3f246a83d0001ab6775",
+                "name": "usco2000.xls",
+                "_modelType": "item"
+              },
+              {
+                "id": "59aeb3f246a83d0001ab677b",
+                "name": "datadict2005.html",
+                "_modelType": "item"
+              }
+            ]
+          */
+
+          // do something with selected items here ...
+          
+      },
+      openSelectDataModal() {
+          $('.ui.modal.selectdata').modal('show');
+      },
     }
 });

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -78,7 +78,7 @@
     {{/unless}}
     {{!-- {{#if (eq internalState.currentInstanceId model.id)}} --}}
     {{#if hasSelectedTaleInstance}}
-        {{ui/tale-tabs-selector model=model openSelectDataModal=(action 'openSelectDataModal') sessionData=sessionData}}
+        {{ui/tale-tabs-selector model=model openSelectDataModal=(action 'openSelectDataModal') session=session }}
     {{else}}
         <div class="placeholder message">
             <p>Choose from

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -78,7 +78,7 @@
     {{/unless}}
     {{!-- {{#if (eq internalState.currentInstanceId model.id)}} --}}
     {{#if hasSelectedTaleInstance}}
-        {{ui/tale-tabs-selector model=model}}
+        {{ui/tale-tabs-selector model=model openSelectDataModal=(action 'openSelectDataModal') sessionData=sessionData}}
     {{else}}
         <div class="placeholder message">
             <p>Choose from
@@ -131,3 +131,5 @@
         </div>
     </div>
 </div>
+
+{{ui/select-data-modal updateSessionData=(action "updateSessionData") allSelectedItems=allSelectedItems}}

--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -9,6 +9,16 @@
         </tr>
       </thead>
       <tbody>
+         {{#each sessionList as |item|}}
+          <tr class="left aligned contextmenu" id={{item.id}}>
+              <td>
+                {{{file-icon-for item.name}}} {{truncate-name item.name}}
+              </td>
+              <td >
+                  --
+              </td>
+          </tr>
+        {{/each}}
         {{#each folderList as |item|}}
             <tr class="left aligned contextmenu" id="{{item.id}}" style="height: 45px !important;">
                 <td>

--- a/app/components/ui/select-data-modal/component.js
+++ b/app/components/ui/select-data-modal/component.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import Object, { computed } from '@ember/object';
 import { A } from '@ember/array';
-import { observer } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 const O = Object.create.bind(Object);
@@ -37,10 +36,6 @@ export default Component.extend({
             let newClass = `select-data-modal-${this.get('modelType')}`;
             return newClass;
         } else return '';
-    }),
-
-    asio: observer('allSelectedItems', function() {
-      console.log(this.allSelectedItems);
     }),
 
     actions: {
@@ -179,10 +174,10 @@ export default Component.extend({
     addSelectedData(files, folders) {
         const self = this;
         const add = f => {
-            if (f.selected) {
-                f.set('selected', false);
-                let { id, name, _modelType } = f;
-                if (!self.allSelectedItems.findBy('id', id)) {
+          if (f.selected) {
+            f.set('selected', false);
+            let { id, name, _modelType } = f;
+            if (!self.allSelectedItems.findBy('id', id)) {
                     self.allSelectedItems.pushObject(O({ id, name, _modelType }));
                 }
             }

--- a/app/components/ui/select-data-modal/component.js
+++ b/app/components/ui/select-data-modal/component.js
@@ -75,6 +75,19 @@ export default Component.extend({
 
         removeSelectedData() {
             this.removeSelectedData.call(this);
+        },
+
+        close() {
+          const deselect = f => {
+            if (f.selected) {
+              f.set('selected', false);
+            }
+          }
+          this.allSelectedItems.forEach(deselect);
+          this.set('folders', A());
+          this.set('files', A());
+          this.set('currentFolder', null);
+          this.set('rootFolderId', null);
         }
     },
 
@@ -210,11 +223,8 @@ export default Component.extend({
     },
 
     cancel() {
-        this.set('allSelectedItems', A());
-        this.set('folders', A());
-        this.set('files', A());
-        this.set('currentFolder', null);
-        this.set('rootFolderId', null);
+        
+        // this.set('allSelectedItems', A());
 
         // NOTE(Adam): This causes an infinite loop where the function calls itself recursively forever.
 

--- a/app/components/ui/select-data-modal/component.js
+++ b/app/components/ui/select-data-modal/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import Object, { computed } from '@ember/object';
 import { A } from '@ember/array';
+import { observer } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 const O = Object.create.bind(Object);
@@ -36,6 +37,10 @@ export default Component.extend({
             let newClass = `select-data-modal-${this.get('modelType')}`;
             return newClass;
         } else return '';
+    }),
+
+    asio: observer('allSelectedItems', function() {
+      console.log(this.allSelectedItems);
     }),
 
     actions: {
@@ -88,7 +93,7 @@ export default Component.extend({
         this.set('loadError', false);
         this.set('loadingMessage', 'Preparing Files');
 
-        this.set('allSelectedItems', A());
+        // this.set('allSelectedItems', A());
         this.set('folders', A());
         this.set('files', A());
         this.set('currentFolder', null);
@@ -210,10 +215,18 @@ export default Component.extend({
     },
 
     cancel() {
-        if (this.get('cancel')) {
-            this.get('cancel')();
-        } else {
-            throw new Error('[select-data-modal] "cancel" function must be provided!!');
-        }
+        this.set('allSelectedItems', A());
+        this.set('folders', A());
+        this.set('files', A());
+        this.set('currentFolder', null);
+        this.set('rootFolderId', null);
+
+        // NOTE(Adam): This causes an infinite loop where the function calls itself recursively forever.
+
+        // if (this.get('cancel')) {
+        //     this.get('cancel')();
+        // } else {
+        //     throw new Error('[select-data-modal] "cancel" function must be provided!!');
+        // }
     }
 });

--- a/app/components/ui/select-data-modal/template.hbs
+++ b/app/components/ui/select-data-modal/template.hbs
@@ -1,4 +1,4 @@
-{{#ui-modal class="selectdata" name="selectdata" onVisible=(action 'initData')}}
+{{#ui-modal class="selectdata" name="selectdata" onVisible=(action 'initData') onHide=(action 'close')}}
     <div class="header">
         Select Data
     </div>

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -6,6 +6,8 @@ import { observer, computed } from '@ember/object';
 import Object from '@ember/object';
 import $ from 'jquery';
 
+const O = Object.create.bind(Object);
+
 function wrapFolder(folderID, folderName) {
     return {
         "name": folderName,
@@ -31,8 +33,6 @@ export default Component.extend({
     store: service(),
     folderNavs: service(),
     router: service(),
-
-    sessionData: A(),
 
     fileBreadCrumbs: computed(function () {
         return {};
@@ -199,19 +199,20 @@ export default Component.extend({
                 });
                 // alert("Not implemented yet ...");
             } else if (nav.command === "user_data") {
-              let sessionId = controller.model.get('sessionId');
+              let session, sessionId = controller.model.get('sessionId');
               let sessionContents = controller.get('store').findRecord('dm', sessionId, { adapterOptions: { insertPath: 'session' }})
-                .then(session => {
+                .then(_session => {
+                  session = _session;
                   return session.get('dataSet').map(item => {
                     let {itemId, mountPath} = item;
-                    return {id: itemId, name: mountPath.replace(/\//g, '') };
+                    return O({id: itemId, name: mountPath.replace(/\//g, '') });
                   });
                 })
               ;
               itemContents = Promise.resolve(A([]));
               folderContents = sessionContents.then(_sessionContents => {
                 newModel.sessionContents = _sessionContents;
-                controller.set('sessionData', A(_sessionContents));
+                controller.set('session', session);
                 return A();
               });
             }

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -1,6 +1,6 @@
 import TextField from '@ember/component/text-field';
 import Component from '@ember/component';
-import { A } from '@ember/array'; 
+import { A } from '@ember/array';
 import { inject as service } from '@ember/service';
 import { observer, computed } from '@ember/object';
 import Object from '@ember/object';
@@ -31,6 +31,8 @@ export default Component.extend({
     store: service(),
     folderNavs: service(),
     router: service(),
+
+    sessionData: A(),
 
     fileBreadCrumbs: computed(function () {
         return {};
@@ -202,13 +204,14 @@ export default Component.extend({
                 .then(session => {
                   return session.get('dataSet').map(item => {
                     let {itemId, mountPath} = item;
-                    return {id: itemId, name: mountPath };
+                    return {id: itemId, name: mountPath.replace(/\//g, '') };
                   });
                 })
               ;
               itemContents = Promise.resolve(A([]));
               folderContents = sessionContents.then(_sessionContents => {
                 newModel.sessionContents = _sessionContents;
+                controller.set('sessionData', A(_sessionContents));
                 return A();
               });
             }
@@ -369,39 +372,12 @@ export default Component.extend({
         //-----------------------------------------------------------------------------
         openRegisterModal() {
             $('.ui.modal.harvester').modal('show');
-        },
-        updateSessionData(listOfSelectedItems) {
-            // console.log('updating session data...');
-            // NOTE: Structure of the list looks like this:
-
-            /*
-              [
-                {
-                  "id": "59aeb3f246a83d0001ab6777",
-                  "name": "us85co.xls",
-                  "_modelType": "item"
-                },
-                {
-                  "id": "59aeb3f246a83d0001ab6775",
-                  "name": "usco2000.xls",
-                  "_modelType": "item"
-                },
-                {
-                  "id": "59aeb3f246a83d0001ab677b",
-                  "name": "datadict2005.html",
-                  "_modelType": "item"
-                }
-              ]
-            */
-
-            // do something with selected items here ...
-        },
-        openSelectDataModal() {
-            $('.ui.modal.selectdata').modal('show');
-        },
+        }, 
         closeSelectDataModal() {
             $('.ui.modal.selectdata').modal('hide');
+        },
+        openSelectDataModal() {
+            this.sendAction('openSelectDataModal');
         }
-
     }
 });

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -198,22 +198,24 @@ export default Component.extend({
                 // alert("Not implemented yet ...");
             } else if (nav.command === "user_data") {
               let sessionId = controller.model.get('sessionId');
-              folderContents = controller.get('store').findRecord('dm', sessionId, { adapterOptions: { insertPath: 'session' }})
+              let sessionContents = controller.get('store').findRecord('dm', sessionId, { adapterOptions: { insertPath: 'session' }})
                 .then(session => {
-                  console.log('session', session);
                   return session.get('dataSet').map(item => {
                     let {itemId, mountPath} = item;
-                    return {id: itemId, name: mountPath, _modelType: 'item' };
+                    return {id: itemId, name: mountPath };
                   });
                 })
               ;
               itemContents = Promise.resolve(A([]));
+              folderContents = sessionContents.then(_sessionContents => {
+                newModel.sessionContents = _sessionContents;
+                return A();
+              });
             }
 
             let newModel = {};
             folderContents
                 .then(_folderContents => {
-                    console.log('folder contents', _folderContents);
                     newModel.folderContents = _folderContents;
                     return itemContents;
                 })

--- a/app/components/ui/tale-tab-files/template.hbs
+++ b/app/components/ui/tale-tab-files/template.hbs
@@ -49,4 +49,3 @@
 
 {{ui/files/create-folder-modal onNewFolder=(action "insertNewFolder")}}
 {{ui/files/registration-modal onRegisterData=(action "refresh")}}
-{{ui/select-data-modal updateSessionData=(action "updateSessionData") cancel=(action "closeSelectDataModal")}}

--- a/app/components/ui/tale-tab-files/template.hbs
+++ b/app/components/ui/tale-tab-files/template.hbs
@@ -36,7 +36,7 @@
     <div class="eleven wide column">
         <div class="ui collapsable grid" style="margin-left: 10px">
             <div class="sixteen wide right aligned column">
-                {{ui/files/directory-browser currentNav=currentNav folderList=fileData.folderContents fileList=fileData.itemContents onItemClicked=(action 'itemClicked')}}
+                {{ui/files/directory-browser currentNav=currentNav sessionList=fileData.sessionContents folderList=fileData.folderContents fileList=fileData.itemContents onItemClicked=(action 'itemClicked')}}
             </div>
             {{#unless currentBreadCrumb.isCollection}}
                 <div class="sixteen wide column overlay">

--- a/app/components/ui/tale-tabs-selector/component.js
+++ b/app/components/ui/tale-tabs-selector/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import layout from './template';
+// import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 export default Component.extend({
     layout,
@@ -31,5 +32,8 @@ export default Component.extend({
             this.set("activeTabFiles", false);
             this.set("activeTabMetadata", true);
         },
+        openSelectDataModal() {
+            this.sendAction('openSelectDataModal');
+        }
     }
 });

--- a/app/components/ui/tale-tabs-selector/template.hbs
+++ b/app/components/ui/tale-tabs-selector/template.hbs
@@ -16,7 +16,7 @@
     </div>
     <div class="ui tab {{if activeTabFiles "active"}}" data-tab="tab-files">
         {{#if activeTabFiles}}
-            {{ui/tale-tab-files model=model}}
+            {{ui/tale-tab-files model=model openSelectDataModal=(action 'openSelectDataModal') sessionData=sessionData}}
         {{/if}}
     </div>
     <div id="taleMetadataTab" class="ui tab {{if activeTabMetadata "active"}}" data-tab="tab-metadata">

--- a/app/components/ui/tale-tabs-selector/template.hbs
+++ b/app/components/ui/tale-tabs-selector/template.hbs
@@ -16,7 +16,7 @@
     </div>
     <div class="ui tab {{if activeTabFiles "active"}}" data-tab="tab-files">
         {{#if activeTabFiles}}
-            {{ui/tale-tab-files model=model openSelectDataModal=(action 'openSelectDataModal') sessionData=sessionData}}
+            {{ui/tale-tab-files model=model openSelectDataModal=(action 'openSelectDataModal') session=session}}
         {{/if}}
     </div>
     <div id="taleMetadataTab" class="ui tab {{if activeTabMetadata "active"}}" data-tab="tab-metadata">

--- a/app/models/custom-inflector-rules.js
+++ b/app/models/custom-inflector-rules.js
@@ -16,6 +16,7 @@ inflector.uncountable('sils');
 inflector.uncountable('recipe');
 inflector.uncountable('group');
 inflector.uncountable('job');
+inflector.uncountable('dm');
 
 // Meet Ember Inspector's expectation of an export
 export default {};

--- a/app/models/dm.js
+++ b/app/models/dm.js
@@ -1,0 +1,25 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  _accessLevel: DS.attr(),
+  _id: DS.attr(),
+  _modelType: DS.attr('string'),
+  ownerId: DS.attr('string'),
+  /* --- dataSet ----
+  [
+    {
+      "itemId": "5c1273173fea9e0001a54a93",
+      "mountPath": "/datadict2000.html"
+    },
+    {
+      "itemId": "5c1273193fea9e0001a54a95",
+      "mountPath": "/datadict2005.html"
+    },
+    {
+      "itemId": "5c12731a3fea9e0001a54a97",
+      "mountPath": "/dictionary95.txt"
+    }
+  ]
+  */
+  dataSet: DS.attr()
+});

--- a/app/models/instance.js
+++ b/app/models/instance.js
@@ -5,17 +5,19 @@ export default DS.Model.extend({
   _id: DS.attr('string'),
   _modelType: DS.attr('string'),
   containerInfo: DS.attr(),
-// contains
-//   "containerId": "397914f6bf9e4d153dd86e147b4fc872c67642ce54da3a58ae97dd8cd2b6d622",
-//  "containerPath": "user/hkhHpMloA4Pp/login?token=babf41833c9641a4a92bece48a34e5b7",
-//  "host": "172.17.0.1",
-//  "mountPoint": "/var/lib/docker/volumes/58caa69f9fcbde0001df4d26_ianjtaylor/_data",
-//  "volumeName": "58caa69f9fcbde0001df4d26_ianjtaylor"
+
+  // contains
+  //   "containerId": "397914f6bf9e4d153dd86e147b4fc872c67642ce54da3a58ae97dd8cd2b6d622",
+  //   "containerPath": "user/hkhHpMloA4Pp/login?token=babf41833c9641a4a92bece48a34e5b7",
+  //   "host": "172.17.0.1",
+  //   "mountPoint": "/var/lib/docker/volumes/58caa69f9fcbde0001df4d26_ianjtaylor/_data",
+  //   "volumeName": "58caa69f9fcbde0001df4d26_ianjtaylor",
 
   created: DS.attr('date'),
   creatorId: DS.attr('string'),
   lastActivity: DS.attr('string'),
   name: DS.attr('string'),
+  sessionId: DS.attr('string'),
   status: DS.attr('number'),
   taleId: DS.attr('string'),
   url: DS.attr('string'),


### PR DESCRIPTION
This PR hooks up the select data modal to the external data tab and also updates the session data for the running tale when the user hits select on the modal.

This PR also adds custom rules for the /dm endpoint in the REST Adapter because the dm endpoint is not implemented in a standard RESTful way. There are 3 things to note about the `/dm` endpoint here:

1. The emberjs framework updates models using PATCH, but the dm endpoint uses PUT. So I have to override this in the adapter.
1. The model endpoints should not have nested paths. It should look like this `/dm/{id}`, where the model is `dm`. But instead the dm endpoint looks  like this `/dm/session/{id}` which forces me to have to override emberjs and insert `session` into the url.
1. Also, it is standard to send a JSON body with a request to PUT or PATCH, but the `/dm` endpoint uses query params instead. This is very non-standard. So again, I have to override the emberjs adapter to insert a query string in the url.

(*Important note*: Calling PUT `/dm/session/{id}` returns a status of 200 which is good. And GET `/dm/session/{id}` does show the files I selected to update the session. However, when I check the actual files in the running tale, I still see the original files when I first composed the tale. This is a bug on the backend? I don't know.)