### PR TITLE
Update Tale model to use 'dataSet' instead of 'involatileData'. Fixes #351

### DIFF
--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -390,8 +390,8 @@ export default Component.extend({
         // Check that the object is a folder/item
         if (x.hasOwnProperty('id')) {
             formattedData.push({
-            'type': x.get('isFolder') ? 'folder' : 'item',
-            'id': x.get('id')
+              'mountPath': '/' + x.get('name'),
+              'itemId': x.get('id')
             });
         }
       });
@@ -399,7 +399,7 @@ export default Component.extend({
       let name = this.get('newTaleName').trim();
       let new_tale = this.get('store').createRecord('tale', {
         "config": {}, //TODO: Implement configuration editor
-        "involatileData": formattedData,
+        "dataSet": formattedData,
         "imageId": this.get('selectedEnvironment').get('_id'),
         "title": name
       });

--- a/app/models/tale.js
+++ b/app/models/tale.js
@@ -17,6 +17,6 @@ export default DS.Model.extend({
   "published": DS.attr('boolean'),
   "title": DS.attr('string'),
   "updated": DS.attr('date'),
-  "involatileData": DS.attr(),
+  "dataSet": DS.attr(),
   "folderId": DS.attr('string')
 });


### PR DESCRIPTION
Changes complementary to https://github.com/whole-tale/girder_wholetale/pull/213

### How to test?
1. Compose a Tale with data
2. Verify that data is accessible in a running container.