### PR TITLE
Run > Files > External Data fixes

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -27,13 +27,6 @@ export default Component.extend(FullScreenMixin, {
 
     session: O({dataSet:A()}),
 
-    allSelectedItems: computed('session', function() {
-      return A(this.session.get('dataSet').map(item => {
-        let {itemId, mountPath} = item;
-        return O({id: itemId, name: mountPath.replace(/\//g, '') });
-      }));
-    }),
-
     init() {
         this._super(...arguments);
         let state = this.get('internalState');
@@ -172,20 +165,5 @@ export default Component.extend(FullScreenMixin, {
         denyDelete() {
             return true;
         },
-        updateSessionData(listOfSelectedItems) {
-          let dataSet = listOfSelectedItems.map(item => {
-            let {id, name} = item;
-            return {itemId: id, mountPath: name};
-          });
-          this.session.set('dataSet', dataSet);
-          this.session.save()
-            .then(() => {
-              // TODO(Adam): Somehow refresh the state of the external data tab to reflect the changes made to the session.
-            })
-          ;
-      },
-      openSelectDataModal() {
-          $('.ui.modal.selectdata').modal('show');
-      },
     }
 });

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -77,7 +77,7 @@
         </div>
     {{/unless}}
     {{#if hasSelectedTaleInstance}}
-        {{ui/tale-tabs-selector model=model  workspaceRootId=workspaceRootId openSelectDataModal=(action 'openSelectDataModal') session=session }}
+        {{ui/tale-tabs-selector model=model workspaceRootId=workspaceRootId session=session }}
     {{else}}
         <div class="placeholder message">
             <p>Choose from
@@ -130,5 +130,3 @@
         </div>
     </div>
 </div>
-
-{{ui/select-data-modal updateSessionData=(action "updateSessionData") allSelectedItems=allSelectedItems}}

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -47,6 +47,13 @@ export default Component.extend({
     currentNavTitle: 'Home',
     parentId: null,
     file: '',
+    
+    allSelectedItems: computed('model.tale', function(dataSet) {
+      return A(this.get('model.tale').get('dataSet').map(item => {
+        let {itemId, mountPath} = item;
+        return O({id: itemId, name: mountPath.replace(/\//g, '') });
+      }));
+    }),
 
     fileChosen: observer('file', function () {
         if (this.get('file') === '') return;
@@ -90,8 +97,13 @@ export default Component.extend({
         this.set('fileBreadCrumbs', state.getCurrentFileBreadcrumbs()); // new collection, reset crumbs
 
     },
+    resync() {
+        let nav = this.get('currentNav');
+        this.send('navClicked', nav);
+    },
 
     actions: {
+        
         refresh() {
             let state = this.get('internalState');
             let myController = this;
@@ -239,37 +251,18 @@ export default Component.extend({
                 folderContents = controller.get('store').query('resource', {
                     'resources': payload
                 });
-                // alert('Not implemented yet ...');
-            } else if (nav.command === 'user_data') {
-                let sessionId = controller.model.get('sessionId');
-                let sessionContents = controller.get('store').findRecord('dm', sessionId, { adapterOptions: { insertPath: 'session' }})
-                    .then(session => {
-                        return session.get('dataSet').map(item => {
-                            let { itemId, mountPath } = item;
-                            return { id: itemId, name: mountPath };
-                        });
-                    });
-                itemContents = Promise.resolve(A([]));
-                folderContents = sessionContents.then(_sessionContents => {
-                    newModel.sessionContents = _sessionContents;
-                    return A();
-                });
-                // alert("Not implemented yet ...");
             } else if (nav.command === "user_data") {
-              let session, sessionId = controller.model.get('sessionId');
-              let sessionContents = controller.get('store').findRecord('dm', sessionId, { adapterOptions: { insertPath: 'session' }})
-                .then(_session => {
-                  session = _session;
-                  return session.get('dataSet').map(item => {
-                    let {itemId, mountPath} = item;
-                    return O({id: itemId, name: mountPath.replace(/\//g, '') });
-                  });
-                })
-              ;
+              let taleId = this.get('model.taleId'); // state.currentInstanceId;
+                let taleDatasetContents = controller.get('store').findRecord('tale', taleId)
+                    .then(tale => {
+                        return tale.get('dataSet').map(dataset => {
+                            let { itemId, mountPath } = dataset;
+                            return { id: itemId, name: mountPath };
+                        })
+                    });
               itemContents = Promise.resolve(A([]));
-              folderContents = sessionContents.then(_sessionContents => {
-                newModel.sessionContents = _sessionContents;
-                controller.set('session', session);
+              folderContents = taleDatasetContents.then(_taleDatasetContents => {
+                newModel.sessionContents = _taleDatasetContents;
                 return A();
               });
             }
@@ -452,11 +445,28 @@ export default Component.extend({
                 }
               ]
             */
+            let context = this;
 
-            // do something with selected items here ...
+            // Build up our dataSet list
+            let dataSet = listOfSelectedItems.map(item => {
+                let {id, name} = item;
+                return {itemId: id, mountPath: name};
+            });
+            this.session.set('dataSet', dataSet);
+          
+            // Look up the current Tale by id
+            let taleId = this.get('model.taleId');
+            this.get('store').findRecord('tale', taleId)
+                .then(tale => {
+                    // Overwrite Tale dataSet with selected datasets
+                    tale.set('dataSet', dataSet);
+                    tale.save();
+                    //console.log("Saved dataSet:", dataSet);
+                    context.resync();
+                });
         },
         openSelectDataModal() {
-            this.sendAction('openSelectDataModal');
+            $('.ui.modal.selectdata').modal('show');
         },
         closeSelectDataModal() {
             $('.ui.modal.selectdata').modal('hide');

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -463,6 +463,9 @@ export default Component.extend({
                     tale.save();
                     //console.log("Saved dataSet:", dataSet);
                     context.resync();
+                    
+                    // XXX: We shouldn't have to call this manually
+                    context.actions.closeSelectDataModal();
                 });
         },
         openSelectDataModal() {

--- a/app/components/ui/tale-tab-files/template.hbs
+++ b/app/components/ui/tale-tab-files/template.hbs
@@ -50,7 +50,7 @@
 
 {{ui/files/create-folder-modal onNewFolder=(action "insertNewFolder")}}
 {{ui/files/registration-modal onRegisterData=(action "refresh")}}
-{{ui/select-data-modal updateSessionData=(action "updateSessionData") cancel=(action "closeSelectDataModal")}}
+{{ui/select-data-modal updateSessionData=(action "updateSessionData") allSelectedItems=allSelectedItems cancel=(action "closeSelectDataModal")}}
 {{ui/files/workspaces-data-modal
     updateWorkspaceData=(action "updateWorkspaceData")
     cancel=(action "closeWorkspacesDataModal")}}


### PR DESCRIPTION
This is a rather large / inter-dependent PR, but sadly these are very related - to the point that it would take a lot longer to do/review them as separate PRs.

I apologize in advance for the complexity here.

## Related Issues
* ~Depends on #359~
* ~Depends on https://github.com/whole-tale/girder_wholetale/pull/218~
* ~Depends on https://github.com/whole-tale/girder_wholetale/pull/213~
* ~Depends on https://github.com/whole-tale/gwvolman/pull/45~
* ~Depends on https://github.com/whole-tale/girder_wt_data_manager/pull/36~
* Fixes #355 - External Data nav on Run > Files tab should now be reading from `tale.dataSets` instead of `/dm/session` or `tale.involatileData`
* Fixes #354 - Left pane of Select Data modal should now list from the `WholeTale Catalog`, instead of user's own registered datasets
* Fixes #350 - added a hacky `resync()` function that recycles existing logic
* Fixes #352 - `allSelectedItems` should now be built up from the `dataSet` object on the tale
* Fixes #353 - `this.session.save()` was being used, so I adjusted this to save the selected dataSets to `/tale/:id` instead, and the duplicate modal no longer launches
* If I can figure it out quickly enough, I may attempt to add #354 here as well (since it will also depend on all of the above)

## Changes
* Consolidated duplicate "Select Data" modal logic - moved this down from the `run` component into the `tale-tab-files` component
* Changed remaining references in the `run` / `tale-tab-files` components from `tale.involatileData` to instead use `tale.dataSet`
* Changed `this.session.save()` to instead call PUT `/tale/:id` to save selected data from the "Select Data" modal

## How to Test
Assuming all related/dependent PRs have been merged:
1. Use [the deploy-dev "dev" branch](https://github.com/whole-tale/deploy-dev/tree/dev) to map in and run all of the dependent branches together (see above)
2. Login to Whole Tale Dashboard
3. If you haven't already, register a Dataset (e.g. `doi:10.18739/A29G5GD0V`)
    * NOTE: You may need to wait for registration to complete
4. Compose a new Tale if you haven't already
    * NOTE: Tale version has been updated to 4
    * If you choose an older Tale, please ensure that it has migrated properly to version 4 (e.g. `format` should be `4`, and you should now see ` dataSet` instead of `involatileData`)
5. Launch the Tale, navigate to Run > Files, and click "External Data"
    * You should not yet see any datasets listed here
6. At the top-right of the panel, click the (+) button
    * You should be presented with the "Select Data" modal
    * On the left, you should see all datasets registered by all users (#354) - NOTE: This no longer needs to match the listed output from Manage > Data, and should instead be the union of all users' registered datasets
    * The right side should match the External Data nav of the Run > Files tab - e.g. you should not yet see any datasets listed here
7. Add the dataset you just registered by selecting it on the left and clicking "Add Selected"
    * You should see the registered dataset appear on the right side
8. Click "Select" at the bottom-right of the modal window
    * The modal window should dismiss itself
    * You should still be at the Run > Files view with the External Data nav selected
    * You should see the selected data has resynced and now appears in the file list (#353)
    * You should no longer see a duplicate "Select Data" modal after dismissing the first one (#353)
9. Using SwaggerUI, examine the Tale object you just created
    * You should see the `dataSet` field has been populated with the id of the dataSet you just added (#350)
10. Click the (+) button to open the "Select Data" modal again
    * You should see the data you just added now appears on the right side, which should still match your "External Data" file list from the Run > Files view (#352)