### PR TITLE
Hide 'Data' panel (bottom-right) from Run and Compose views

### DIFF
--- a/app/components/dashboard/compose/right-panel/component.js
+++ b/app/components/dashboard/compose/right-panel/component.js
@@ -5,7 +5,7 @@ export default Component.extend({
   wtEvents: service(),
   classNameBindings: ['showUpperPanel', 'showLowerPanel'],
   showUpperPanel: true,
-  showLowerPanel: true,
+  showLowerPanel: false,
 
   init() {
     this._super(...arguments);

--- a/app/components/dashboard/run/right-panel/component.js
+++ b/app/components/dashboard/run/right-panel/component.js
@@ -7,7 +7,7 @@ export default Ember.Component.extend({
 
   classNameBindings: ['showUpperPanel', 'showLowerPanel'],
   showUpperPanel: true,
-  showLowerPanel: true,
+  showLowerPanel: false,
 
   actions: {
     onLeftModelChange : function (model) {


### PR DESCRIPTION
# Problem
Fixes #362

With the new view at Run > Files > External Data being fully-functional, we need to adjust the `ui/files/mini-browser` (aka the "Data" panel) to account for the new changes to the Tale format and data manipulation workflows. In order to expedite the upcoming release, we are temporarily hiding these features from the UI.

# Approach
Since both `run/right-panel` and `compose/right-panel` had already defined a boolean for `showLowerPanel`, we just needed to toggle this to false to temporarily hide the "Data" panel from the user.

# How to Test
1. Check out this branch
2. Rebuild the dashboard
3. Navigate to the "Compose" view
    * You should no longer see the "Data" panel at the bottom-right
4. Navigate to the "Run" view (create a new tale first, if necessary)
    * You should no longer see the "Data" panel at the bottom-right