### PR TITLE
 Respect 'adapterOptions.queryParams' in urlForQuery. Fixes #369

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -109,25 +109,14 @@ export default DS.RESTAdapter.extend(buildQueryParamsMixin, {
         let url = this._super(query, modelName);
 
         if (query.adapterOptions) {
-            if (query.adapterOptions.registered) {
-                url += "/registered";
-            } else if (query.adapterOptions.icon) {
-                let queryParams = query.adapterOptions.queryParams;
-                if (queryParams) {
-                    let q = this.buildQueryParams(queryParams);
-                    url += "?" + q;
-                }
-                url += "/icon";
-            } else if (query.adapterOptions.appendPath) {
+            if (query.adapterOptions.appendPath) {
                 url += "/" + query.adapterOptions.appendPath;
-                let queryParams = query.adapterOptions.queryParams;
-                if (queryParams) {
-                    let q = this.buildQueryParams(queryParams);
-                    url += "?" + q;
-                }
+            }
+            if (query.adapterOptions.queryParams) {
+                let q = this.buildQueryParams(query.adapterOptions.queryParams);
+                url += "?" + q;
             }
         }
-
         return url;
     },
 

--- a/app/components/ui/select-data-modal/component.js
+++ b/app/components/ui/select-data-modal/component.js
@@ -190,7 +190,7 @@ export default Component.extend({
 
         const store = this.get('store');
         let fetchFolders = store.query('folder', { parentId, parentType, adapterOptions });
-        let fetchFiles = store.query('item', { folderId: parentId });
+        let fetchFiles = store.query('item', { folderId: parentId, adapterOptions });
 
         const self = this;
         return Promise.all([fetchFolders, fetchFiles]).then(([folders, files]) => {

--- a/app/routes/compose/index.js
+++ b/app/routes/compose/index.js
@@ -32,7 +32,7 @@ export default AuthenticateRoute.extend({
     let registered = this.get('store').query('folder', {
       reload: true,
       adapterOptions: {
-        registered: true,
+        appendPath: "registered",
         queryParams: {
           limit: "0"
         }

--- a/app/routes/compose/new.js
+++ b/app/routes/compose/new.js
@@ -20,7 +20,7 @@ export default AuthenticateRoute.extend({
     });
     let registered = this.get('store').query('folder', {
       adapterOptions: {
-        registered: true,
+        appendPath: "registered",
         queryParams: {
           limit: "0"
         }

--- a/app/routes/explore.js
+++ b/app/routes/explore.js
@@ -25,7 +25,7 @@ export default AuthenticateRoute.extend({
         dataRegistered: this.get('store').query('folder', {
           reload: true,
           adapterOptions: {
-            registered: true,
+            appendPath: "registered",
             queryParams: {
               limit: "0"
             }

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -68,7 +68,7 @@ export default AuthenticateRoute.extend({
           dataRegistered: this.get('store').query('folder', {
             reload: true,
             adapterOptions: {
-              registered: true,
+              appendPath: "registered",
               queryParams: {
                 limit: "0"
               }

--- a/app/routes/pcompose.js
+++ b/app/routes/pcompose.js
@@ -22,7 +22,7 @@ export default AuthenticateRoute.extend({
     let registered = this.get('store').query('folder', {
       reload: true,
       adapterOptions: {
-        registered: true,
+        appendPath: "registered",
         queryParams: {
           limit: "0"
         }


### PR DESCRIPTION
### Description
Since some of the API endpoints do not conform to the standard that EmberJS expects, we hand craft certain urls upon invocation of native EmberJS `.get` calls. As an example for parameters of type *query* we call `app/adapters/application.js:urlForQuery`.

This PR introduces several changes to urlForQuery method:

1. Simplify logic for customizing url query parameter
1. Always append query parameters if `adapterOptions.queryParams` if present.
1. Remove unused `adapterOptions.icon` logic branch.
1. Use generic `adapterOptions.appendPath` approach for `/registered` path instead of a custom logic branch.

### How to test?
1. Deploy WT locally with this branch
1. Go to https://dashboard.local.wholetale.org
1. Run > Files > external_data > Select Data modal
1. In Dev Console confirm that requests to `GET /item` and `GET /folder` contain `limit=0` parameter.