### PR TITLE
Store _modelType in dataSet to render proper folder/item icons

### DIFF
--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -16,7 +16,11 @@
             {{#each sessionList as |item|}}
                 <tr class="left aligned contextmenu" id="{{item.id}}">
                     <td colspan="3">
-                        {{{file-icon-for item.name}}} {{item.name}}
+                        {{#if (eq item._modelType "folder")}}
+                            <i class="large folder icon"></i> {{item.name}}
+                        {{else}}
+                            {{{file-icon-for item.name}}} {{item.name}}
+                        {{/if}}
                     </td>
                 </tr>
             {{/each}}

--- a/app/components/ui/select-data-modal/template.hbs
+++ b/app/components/ui/select-data-modal/template.hbs
@@ -75,7 +75,7 @@
                             {{#each allSelectedItems as | item |}}
                                 <tr class="{{if item.selected 'selected-row'}}">
                                     <td class="collapsing noselect" {{action 'onClick' item on='click'}}>
-                                        {{#if (eq item._modelType 'file')}}
+                                        {{#if (eq item._modelType 'item')}}
                                             <i class="file icon"></i>{{item.name}}
                                         {{else}}
                                             <i class="folder icon"></i>{{item.name}}

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -50,8 +50,8 @@ export default Component.extend({
     
     allSelectedItems: computed('model.tale', function(dataSet) {
       return A(this.get('model.tale').get('dataSet').map(item => {
-        let {itemId, mountPath} = item;
-        return O({id: itemId, name: mountPath.replace(/\//g, '') });
+        let {itemId, mountPath, _modelType} = item;
+        return O({id: itemId, name: mountPath.replace(/\//g, ''), _modelType});
       }));
     }),
 
@@ -271,8 +271,8 @@ export default Component.extend({
                 let taleDatasetContents = controller.get('store').findRecord('tale', taleId)
                     .then(tale => {
                         return tale.get('dataSet').map(dataset => {
-                            let { itemId, mountPath } = dataset;
-                            return { id: itemId, name: mountPath };
+                            let { itemId, mountPath, _modelType } = dataset;
+                            return { id: itemId, name: mountPath, _modelType };
                         })
                     });
               itemContents = Promise.resolve(A([]));
@@ -465,8 +465,8 @@ export default Component.extend({
 
             // Build up our dataSet list
             let dataSet = listOfSelectedItems.map(item => {
-                let {id, name} = item;
-                return {itemId: id, mountPath: name};
+                let {id, name, _modelType} = item;
+                return {itemId: id, mountPath: name, _modelType};
             });
             this.session.set('dataSet', dataSet);
           


### PR DESCRIPTION
Storing additional information about underlying object type in `dataSet` allows to easily render proper icons.

### How to test?
1. Deploy locally (depends on https://github.com/whole-tale/girder_wholetale/pull/221)
1. Register a dataset (e.g. doi:10.5065/D6862DM8)
1. Create a new Tale
1. Navigate to Run > Files > external_data > Select Data modal
1. Add root folder of registered dataset, add a single file from within registered dataset
1. Confirm that the file has a different icon that the folder on the right hand side of the panel.
1. Click 'Select'
1. Confirm that 'external_data' tab shows icons properly.