### PR TITLE
Parse Girder's error message. Fixes #373

### DIFF
--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -322,7 +322,8 @@ export default Component.extend({
     let component = this;
     let onFail = (e) => {
       // deal with the failure here
-      component.set('errorMessage', e);
+      let errorMessage = (e.responseJSON ? e.responseJSON.message : self.get('defaultErrorMessage'));
+      component.set('errorMessage', errorMessage);
       component.send('openErrorModal');
     };
 
@@ -380,7 +381,8 @@ export default Component.extend({
 
       let onFail = (e) => {
         // deal with the failure here
-        component.set('errorMessage', e);
+        let errorMessage = (e.responseJSON ? e.responseJSON.message : self.get('defaultErrorMessage'));
+        component.set('errorMessage', errorMessage);
         component.send('openErrorModal');
       };
 


### PR DESCRIPTION
Girder returns `{'type': ..., 'message': ... }` upon error. We should use that...

### How to test?
1. Deploy locally with `girder_wholetale` set to `git checkout 604e043`.
1. Try composing a Tale