### PR TITLE
Tale workspaces fixes

### DIFF
--- a/app/components/ui/files/bread-crumbs/template.hbs
+++ b/app/components/ui/files/bread-crumbs/template.hbs
@@ -16,7 +16,7 @@
                             </a>
                             {{#if (eq currentNav.command 'workspace')}}
                                 <a class="item" onclick={{action 'openWorkspacesDataModal'}}>
-                                    Select Data...
+                                    Import Tale Data...
                                 </a>
                             {{/if}}
                         </div>

--- a/app/components/ui/files/workspaces-data-modal/component.js
+++ b/app/components/ui/files/workspaces-data-modal/component.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import Object, { computed } from '@ember/object';
 import { A } from '@ember/array';
 import { inject as service } from '@ember/service';
-import { next } from '@ember/runloop';
 
 const O = Object.create.bind(Object);
 
@@ -117,9 +116,12 @@ export default Component.extend({
         }
 
         this.set('currentFolder', target);
+        
+        let parentCollection = 'folder';
+        let parentId = target.get('id');
 
         const self = this;
-        return this.loadFolder.call(this, target.get('id'), target.get('_modelType')).catch(e => {
+        return this.loadFolder.call(this, parentId, parentCollection).catch(e => {
             self.set('loadError', true);
             self.set('loadingMessage', 'Failed to load registered data. Please try again');
         });
@@ -130,7 +132,7 @@ export default Component.extend({
         target.set('selected', selected);
     },
 
-    goBack(currentFolder) {
+    goBack(currentFolder, adapterOptions = { queryParams: { limit: "0" } }) {
         this.set('loading', true);
         this.set('loadError', false);
         this.set('loadingMessage', 'Preparing Files');
@@ -155,22 +157,35 @@ export default Component.extend({
         this.set('loadError', false);
         this.set('loadingMessage', 'Preparing Files');
 
+        const workspaceRootId = this.get('internalState').workspaceRootId;
         const store = this.get('store');
-        let fetchFolders = store.query('folder', {
-            parentId,
-            parentType,
-            adapterOptions
-        });
-        let fetchFiles = store.query('item', {
-            folderId: parentId
-        });
-
         const self = this;
-        return Promise.all([fetchFolders, fetchFiles]).then(([folders, files]) => {
-            self.set('folders', A(folders));
-            self.set('files', A(files));
-            self.set('loading', false);
-        });
+        
+        if (parentId == workspaceRootId) {
+            return store.query('workspace', {
+                adapterOptions
+            }).then((workspaces) => {
+                // Should be safe to assume that all workspaces are folders
+                self.set('folders', A(workspaces));
+                self.set('files', A([]));
+                self.set('loading', false);
+            })
+        } else {
+            let fetchFolders = store.query('folder', {
+                parentId,
+                parentType,
+                adapterOptions
+            });
+            let fetchFiles = store.query('item', {
+                folderId: parentId
+            });
+            return Promise.all([fetchFolders, fetchFiles]).then(([folders, files]) => {
+                // Folder and files can be returned, separate them accordingly
+                self.set('folders', A(folders));
+                self.set('files', A(files));
+                self.set('loading', false);
+            });
+        }
     },
 
     addSelectedData(files, folders) {
@@ -224,13 +239,15 @@ export default Component.extend({
     },
 
     loadTaleWorkspaces() {
-        let parentId = this.get('userAuth').getCurrentUserID();
-        let parentType = 'folder';
-
+        const self = this;
+        
+        let parentId = self.get('userAuth').getCurrentUserID();
+        let parentCollection = 'folder';
         let workspaceRootId = this.get('internalState').workspaceRootId;
         this.set('rootFolderId', workspaceRootId);
-        this.set('currentFolder', O({ id: workspaceRootId, _modelType: 'folder', parentCollection: parentType, parentId }));
-        return this.loadFolder(workspaceRootId, 'folder');
+        this.set('currentFolder', O({ id: workspaceRootId, _modelType: 'folder', parentCollection, parentId }));
+
+        return self.loadFolder(workspaceRootId, parentCollection);
     },
 
     updateWorkspaceData() {

--- a/app/components/ui/files/workspaces-data-modal/component.js
+++ b/app/components/ui/files/workspaces-data-modal/component.js
@@ -18,6 +18,13 @@ export default Component.extend({
     ]),
     selectedDataSource: O({}),
 
+    canSubmit: computed('rootFolderId', 'currentFolder', function() {
+        let rootFolderId = this.rootFolderId;
+        let currentFolder = this.currentFolder;
+        let currentFolderId = currentFolder != null ? currentFolder.get('id') : null; 
+        return rootFolderId == currentFolderId;
+    }),
+    
     allSelectedItems: A(),
 
     folders: A(),

--- a/app/components/ui/files/workspaces-data-modal/component.js
+++ b/app/components/ui/files/workspaces-data-modal/component.js
@@ -14,7 +14,7 @@ export default Component.extend({
 
     selectedMenuIndex: 0,
     dataSources: A([
-        O({ name: 'Home', description: 'Global directory accessible across all Tales' }),
+        //O({ name: 'Home', description: 'Global directory accessible across all Tales' }),
         O({ name: 'Tale Workspaces', description: 'Other accessible Tales' })
     ]),
     selectedDataSource: O({}),

--- a/app/components/ui/files/workspaces-data-modal/template.hbs
+++ b/app/components/ui/files/workspaces-data-modal/template.hbs
@@ -51,7 +51,7 @@
                             </thead>
                             <tbody>
                                 {{#each folders as | folder |}}
-                                    {{#unless (eq taleId folder.meta.taleId)}}
+                                    {{#unless (and (eq taleId folder.meta.taleId) (eq rootFolderId currentFolder.id))}}
                                         <tr class="{{if folder.selected 'selected-row'}}"
                                             {{action 'dblClick' folder on='doubleClick'}}
                                             {{action 'onClick' folder on='click'}}>

--- a/app/components/ui/files/workspaces-data-modal/template.hbs
+++ b/app/components/ui/files/workspaces-data-modal/template.hbs
@@ -51,7 +51,7 @@
                             </thead>
                             <tbody>
                                 {{#each folders as | folder |}}
-                                    {{#unless (eq folder.name taleId)}}
+                                    {{#unless (eq taleId folder.meta.taleId)}}
                                         <tr class="{{if folder.selected 'selected-row'}}"
                                             {{action 'dblClick' folder on='doubleClick'}}
                                             {{action 'onClick' folder on='click'}}>
@@ -76,20 +76,22 @@
         </div>
     </div>
     <div class="actions">
-        <div class="ui deny button"
+        <button class="ui deny button"
             style="float: left"
             onclick={{action "cancel" preventDefault=false bubble=false}}>
             Cancel
-        </div>
-        <div class="ui positive right labeled icon button" 
+        </button>
+        <button class="ui positive right labeled icon button" 
+            disabled={{canSubmit}}
             onclick={{action "updateWorkspaceData" false preventDefault=false bubble=false}}>
             <i class="copy icon"></i>
             Copy to Workspace
-        </div>
-        <div class="ui positive right labeled icon button" 
+        </button>
+        <button class="ui positive right labeled icon button" 
+            disabled={{canSubmit}}
             onclick={{action "updateWorkspaceData" true preventDefault=false bubble=false}}>
             <i class="cut icon"></i>
             Move to Workspace
-        </div>
+        </button>
     </div>
 {{/ui-modal}}

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -512,6 +512,7 @@ export default Component.extend({
                 }
               ]
             */
+            const context = this;
 
             // do something with selected items here ...
             if (listOfSelectedItems) {
@@ -523,7 +524,7 @@ export default Component.extend({
                 const currentWorkspaceFolderId = this.get('currentWorkspaceFolderId');
                 let parentType = 'folder';
                 this.get('apiCall').copyToFolder(currentWorkspaceFolderId, parentType, payload, permanently, this.showSuccessfulCopyNotification, this.showFailedCopyNotification, this)
-                    .then(this.openWorkspacesDataModal);
+                context.actions.closeWorkspacesDataModal();
             }
         },
         openWorkspacesDataModal() {

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -522,7 +522,8 @@ export default Component.extend({
                 let payload = JSON.stringify(resources);
                 const currentWorkspaceFolderId = this.get('currentWorkspaceFolderId');
                 let parentType = 'folder';
-                this.get('apiCall').copyToFolder(currentWorkspaceFolderId, parentType, payload, permanently, this.showSuccessfulCopyNotification, this.showFailedCopyNotification, this);
+                this.get('apiCall').copyToFolder(currentWorkspaceFolderId, parentType, payload, permanently, this.showSuccessfulCopyNotification, this.showFailedCopyNotification, this)
+                    .then(this.openWorkspacesDataModal);
             }
         },
         openWorkspacesDataModal() {

--- a/app/models/custom-inflector-rules.js
+++ b/app/models/custom-inflector-rules.js
@@ -17,6 +17,7 @@ inflector.uncountable('recipe');
 inflector.uncountable('group');
 inflector.uncountable('job');
 inflector.uncountable('dm');
+inflector.uncountable('workspace');
 
 // Meet Ember Inspector's expectation of an export
 export default {};

--- a/app/models/workspace.js
+++ b/app/models/workspace.js
@@ -1,0 +1,33 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+import FolderItemMixin from 'wholetale/mixins/folder-item';
+import AccessControlMixin from 'wholetale/mixins/access-control';
+
+export default DS.Model.extend(FolderItemMixin, AccessControlMixin, {
+  _accessLevel: DS.attr(),
+  _id: DS.attr(),
+  _modelType: DS.attr('string'),
+  baseParentType: DS.attr('string'), // folder or item
+  baseParentId: DS.attr('string'), // folder or item
+  // baseParentId: Ember.computed('baseParentType', function() {
+  //     return (this.get('baseParentType') === "collection") ? DS.belongsTo('collection') : DS.belongsTo('folder');
+  // }),
+  // parentType: DS.attr('string'),
+  //items: DS.hasMany('item'),
+  //folders: DS.hasMany('folder', { inverse: 'parent' }),
+  //parent: DS.belongsTo('folder', { inverse: 'folders' }),
+  name : DS.attr('string'),
+  lowerName : DS.attr('string'),
+  description: DS.attr('string'),
+  created: DS.attr('date'),
+  // parentId: Ember.computed('parentCollection', function() {
+  //     return (this.get('parentCollection') === "collection")? DS.belongsTo('collection') : DS.belongsTo('folder');
+  // }),
+  creatorId: DS.attr('string'),
+  public: DS.attr('boolean'),
+  meta : DS.attr(), // this contains a creator object that contains a list of creators..
+  parentId: DS.attr('string'),
+  parentCollection: DS.attr('string'), // folder or item
+  size: DS.attr('number'),
+  updated: DS.attr('date')
+});


### PR DESCRIPTION
### Problem
Some minor issues remained after the initial work toward supporting Tale Workspaces, namely:
* Fixes #363 
* Fixes #364
* Fixes #365

### Approach
* #363 - Comment out the "Home" button for now
* #364 - Wire up some logic to hit the `/workspace` endpoint instead of `/folder` if we are at the workspace root
* #365 - Renamed "Select Data..." to "Import Tale Data..." (TBD)

### How to Test
1. Check out this branch on your dev machine
2. Rebuild the dashboard code
3. Login to the dashboard
4. Create a few Tales, if you haven't already
5. Navigate to Run > Files > Tale Workspaces
    * NOTE: If you haven't added any data to the Workspace, you won't see any folders/items listed here yet
6. At the top-right of the panel, click the (+) button
    * You should see the dropdown appear beneath the button
    * You should see that the "Select Data..." option has been renamed to "Import Tale Data..." (#365)
7. Click on "Import Tale Data..."
    * The "Select Workspace Data" modal should appear
    * This modal should no longer list "Home" on the left side (#363)
    * You should see that this modal now lists Tale Workspace folders by name instead of ID (#364)
8. Choose some folders / items and click "Move to Workspace" at the bottom-right of the modal
    * The modal should close
    * You should receive notifications in the UI that you files are moving
    * As they are moved, you should see the UI automatically update to display your new Workspace contents
9. At the top-right of the panel, click the (+) button, and choose "Import Tale Data..." again
    * You should see that any folders/items that were successfully moved in the previous step no longer appear in their previous locations, but can now be found by clicking down into your current Tale's subfolder(s)
10. Choose some more folders / items and click "Copy to Workspace" at the bottom-right of the modal
    * The modal should close
    * You should receive notifications in the UI that you files are copying
    * As they are copied, you should see the UI automatically update to display your new Workspace contents

### Notes:
- NOTE: I'm seeing some inconsistencies between "Tale Workspaces" tab and the "Select Workspace Data" modal... I would expect the contents of my Tale's current folder in the modal to match the folders/files in the "Tale Workspaces" tab, but this may not always be the case currently
- NOTE: This submission logic (in `tale-files-tab`) was not modified as a part of this pull request
- NOTE: Calling `/resource/copy` on a tale workspace folder still results in the ID of the tale as the destination folder name - will the EventHandlers need to be updated in `wt_home_dir` as well?
- NOTE: Should we filter out current tale from being moved into itself? this already yields an error popup anyway, but we may need to show this if we want the option to copy a Tale's data into itself (is this useful?)
- NOTE: There is still some failing edge case that I can't reliably recreate - some tales are able to "Move to Workspace" just fine, while others fail with this error popup (see **Verbose Error Details** below). In my case, I was trying to import the workspace data from "new jup" into another tale named "new tale". I was able to move another tale into this workspace already, so I'm not sure why this Tale is presenting a problem.

##### Verbose Error Details
Error popup:
```
{"message": "AssertionError: AssertionError()", "trace": ["<FrameSummary file /girder/girder/api/rest.py, line 630 in endpointDecorator>", "<FrameSummary file /girder/girder/api/rest.py, line 1228 in PUT>", "<FrameSummary file /girder/girder/api/rest.py, line 967 in handleRoute>", "<FrameSummary file /girder/girder/api/access.py, line 63 in wrapped>", "<FrameSummary file /girder/girder/api/describe.py, line 709 in wrapped>", "<FrameSummary file /girder/girder/api/v1/resource.py, line 334 in moveResources>", "<FrameSummary file /girder/girder/models/folder.py, line 338 in move>", "<FrameSummary file /girder/girder/models/model_base.py, line 506 in save>", "<FrameSummary file /girder/girder/events.py, line 314 in trigger>", "<FrameSummary file /girder/plugins/wt_home_dir/server/__init__.py, line 80 in handler>", "<FrameSummary file /girder/plugins/wt_home_dir/server/lib/EventHandlers.py, line 106 in run>", "<FrameSummary file /girder/plugins/wt_home_dir/server/lib/EventHandlers.py, line 133 in moveFolder>", "<FrameSummary file /girder/plugins/wt_home_dir/server/lib/WTFilesystemProvider.py, line 201 in moveRecursive>", "<FrameSummary file /usr/local/lib/python3.5/dist-packages/wsgidav/fs_dav_provider.py, line 313 in moveRecursive>"], "type": "internal"}
```

Failing `tale`:
```
{
    "_accessLevel": 2,
    "_id": "5c476423fb23660001e75c95",
    "_modelType": "tale",
    "authors": "Michael Lambert",
    "category": "science",
    "config": {},
    "created": "2019-01-22T18:42:43.307000+00:00",
    "creatorId": "5c377bd4e9aec300015f72ae",
    "dataSet": [
      {
        "itemId": "5c425c187ccff7000177c90b",
        "mountPath": "Photogrammetric scans of aerial photographs of North American glaciers, 1974.  tiffs - Obliques"
      },
      {
        "itemId": "5c47a139fb236600012d527e",
        "mountPath": "Laboratory incubations investigating controls over the soil priming effect"
      }
    ],
    "description": "asdf",
    "folderId": "5c476423fb23660001e75c97",
    "format": 4,
    "icon": "https://raw.githubusercontent.com/whole-tale/jupyter-base/master/squarelogo-greytext-orangebody-greymoons.png",
    "iframe": true,
    "illustration": "https://raw.githubusercontent.com/whole-tale/dashboard/master/public/images/demo-graph2.jpg",
    "imageId": "5c377a16e9aec300015f71c7",
    "narrative": [],
    "narrativeId": "5c378b9ce9aec300015f7637",
    "public": false,
    "published": false,
    "title": "new jup",
    "updated": "2019-01-24T17:00:57.924000+00:00"
  }
```

Associated `workspace`:
```
{
    "_id": "5c476423fb23660001e75c96",
    "_modelType": "folder",
    "access": {
      "groups": [],
      "users": [
        {
          "flags": [],
          "id": "5c377bd4e9aec300015f72ae",
          "level": 2
        }
      ]
    },
    "baseParentId": "5c378b9ce9aec300015f762f",
    "baseParentType": "collection",
    "created": "2019-01-22T18:42:43.309000+00:00",
    "creatorId": null,
    "description": "",
    "lowerName": "new jup",
    "meta": {
      "taleId": "5c476423fb23660001e75c95"
    },
    "name": "new jup",
    "parentCollection": "folder",
    "parentId": "5c378b9ce9aec300015f7630",
    "public": false,
    "size": 0,
    "updated": "2019-01-22T18:42:43.312000+00:00"
  }
```