### PR TITLE
Update Manage > Data and Select Data modal to use /datasets endpoint

### DIFF
--- a/app/adapters/dataset.js
+++ b/app/adapters/dataset.js
@@ -19,12 +19,28 @@ export default DS.RESTAdapter.extend(buildQueryParamsMixin, {
 
     query(store, type, query, recordArray) {
         let url = this.buildURL(type.modelName, null, null, 'query', query);
+        delete query.adapterOptions;
 
         if (this.sortQueryParams) {
             query = this.sortQueryParams(query);
         }
 
-        return this.get('authRequest').send(url, { method: 'GET' });
+        return this.get('authRequest').send(url, { method: 'GET', data: query });
+    },
+    
+    urlForQuery(query, modelName) {
+        let url = this._super(query, modelName);
+
+        if (query.adapterOptions) {
+            if (query.adapterOptions.appendPath) {
+                url += "/" + query.adapterOptions.appendPath;
+            }
+            if (query.adapterOptions.queryParams) {
+                let q = this.buildQueryParams(query.adapterOptions.queryParams);
+                url += "?" + q;
+            }
+        }
+        return url;
     },
 
     urlForUpdateRecord(id, modelName, snapshot) {

--- a/app/components/dashboard/manage/left-panel/component.js
+++ b/app/components/dashboard/manage/left-panel/component.js
@@ -146,10 +146,11 @@ export default Component.extend({
           let parentId = firstResult['_id'];
           controller.get('store').query('folder', { parentId, parentType }).then((folders) => {
             let folderId = folders.content[0]._id;
+            let myData = true;
             
             // Only init after we've located the catalog
             controller.get('store').query('dataset', {
-                reload: true,
+                myData,
                 adapterOptions
               }).then(datasets => {
                 controller.set('datasets', datasets);
@@ -327,7 +328,7 @@ export default Component.extend({
         if (crumbs[i].name === item.get('name')) {
           if (i == 0 && this.get('currentNav') == 'user_data') {
             self.set('fileData', { itemContents: [], folderContents: [] });
-            self.get('store').query('dataset', { adapterOptions }).then(datasets => {
+            self.get('store').query('dataset', { myData: true, adapterOptions }).then(datasets => {
               self.set('datasets', datasets);
             });
           }

--- a/app/components/dashboard/manage/left-panel/template.hbs
+++ b/app/components/dashboard/manage/left-panel/template.hbs
@@ -36,7 +36,7 @@
         <div class="eleven wide column directory-browser-container">
             <div class="ui collapsable grid">
                 <div class="sixteen wide right aligned column">
-                  {{ui/files/directory-browser currentNav=currentNav folderList=fileData.folderContents fileList=fileData.itemContents onItemClicked=(action 'itemClicked')}}
+                  {{ui/files/directory-browser currentNav=currentNav datasetList=datasets loading=loading folderList=fileData.folderContents fileList=fileData.itemContents onItemClicked=(action 'itemClicked')}}
                 </div>
                 <div class="sixteen wide column overlay">
                   {{#unless currentBreadCrumb.isCollection}}

--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -20,17 +20,30 @@
                 <p></p>
             {{/if}}
             {{#each datasetList as |item|}}
-                <tr class="left aligned contextmenu" id="{{item.id}}" style="height: 45px !important;">
+                <tr class="left aligned contextmenu" id="{{item.id}}" style={{if (eq item._modelType 'folder') 'height: 45px !important;' ''}}>
                     <td>
-                        <span onclick={{action 'clickedFolder' item}} style="cursor:pointer;font-weight:900;">
-                            <i class="large grey folder icon"></i> {{truncate-name item.name 50}}
-                        </span>
+                        {{#if (eq item._modelType 'folder')}}
+                            {{!-- When clicking a folder, show the contents --}}
+                            <span style="cursor:pointer;font-weight:900;" onclick={{action 'clickedFolder' item}}>
+                                <i class="large grey folder icon"></i> {{truncate-name item.name 50}}
+                            </span>
+                        {{/if}}
                         {{#ui-dropdown}}
+                            {{!-- When clicking an item, show the dropdown --}}
+                            {{#if (eq item._modelType 'item')}}
+                                <span style="cursor:pointer;" onclick={{action 'clickedFile' item}}>
+                                    {{{file-icon-for item.name}}} {{truncate-name item.name 50}}
+                                </span>
+                            {{/if}}
                             <i class="dropdown icon"></i>
                             <div class="menu">
-                                <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
-                                        class="download icon"></i> Download</a>
-                                <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
+                                <a class="item" href="{{apiUrl}}/{{item._modelType}}/{{item.id}}/download?contentDisposition=attachment">
+                                    <i class="download icon"></i> Download
+                                </a>
+                                {{!-- FIXME: There is not yet a DELETE /dataset endpoint --}}
+                                <a class="item" style="cursor:not-allowed;">
+                                    <i class="trash icon"></i> Remove {{!-- {{action "remove" item}} --}}
+                                </a>
                             </div>
                         {{/ui-dropdown}}
                     </td>

--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -13,6 +13,36 @@
             </tr>
         </thead>
         <tbody>
+            {{#if loading}}
+                <div class="ui active inverted dimmer">
+                    <div class="ui indeterminate medium text loader">Loading, please wait...</div>
+                </div>
+                <p></p>
+            {{/if}}
+            {{#each datasetList as |item|}}
+                <tr class="left aligned contextmenu" id="{{item.id}}" style="height: 45px !important;">
+                    <td>
+                        <span onclick={{action 'clickedFolder' item}} style="cursor:pointer;font-weight:900;">
+                            <i class="large grey folder icon"></i> {{truncate-name item.name 50}}
+                        </span>
+                        {{#ui-dropdown}}
+                            <i class="dropdown icon"></i>
+                            <div class="menu">
+                                <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
+                                        class="download icon"></i> Download</a>
+                                <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
+                            </div>
+                        {{/ui-dropdown}}
+                    </td>
+                    {{!-- <td>{{item.description}}</td> --}}
+                    <td style="text-align: left;">
+                        {{bytes-to-readable item.size}}
+                    </td>
+                    <td>
+                        {{from-now item.updated}}
+                    </td>
+                </tr>
+            {{/each}}
             {{#each sessionList as |item|}}
                 <tr class="left aligned contextmenu" id="{{item.id}}">
                     <td colspan="3">
@@ -44,17 +74,22 @@
                                 <i class="dropdown icon"></i>
                                 <div class="menu">
                                     <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
-                                    <a class="item" {{action "rename" item}}><i class="write square icon"></i>
-                                        Rename...</a>
-                                    {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a> --}}
-                                    {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
-                                        <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                    {{#if (eq currentNav.command 'user_data')}}
+                                        <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
+                                                class="download icon"></i> Download</a>
                                     {{else}}
-                                        <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
+                                        <a class="item" {{action "rename" item}}><i class="write square icon"></i>
+                                            Rename...</a>
+                                        {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a>--}}
+                                        {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
+                                            <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                        {{else}}
+                                            <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
+                                        {{/if}}
+                                        <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
+                                                class="download icon"></i> Download</a>
+                                        <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                     {{/if}}
-                                    <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
-                                            class="download icon"></i> Download</a>
-                                    <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                 </div>
                             {{/ui-dropdown}}
                         {{/if}}
@@ -86,18 +121,23 @@
                                 </a>
                                 <i class="dropdown icon"></i>
                                 <div class="menu">
-                                    <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
-                                    <a class="item" {{action "rename" item}}><i class="write square icon"></i>
-                                        Rename...</a>
-                                    {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a> --}}
-                                    {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
-                                        <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                    {{#if (eq currentNav.command 'user_data')}}
+                                        <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
+                                                class="download icon"></i> Download</a>
                                     {{else}}
-                                        <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
+                                        <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
+                                        <a class="item" {{action "rename" item}}><i class="write square icon"></i>
+                                            Rename...</a>
+                                        {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a> --}}
+                                        {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
+                                            <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                        {{else}}
+                                            <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
+                                        {{/if}}
+                                        <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
+                                                class="download icon"></i> Download</a>
+                                        <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                     {{/if}}
-                                    <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
-                                            class="download icon"></i> Download</a>
-                                    <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                 </div>
                             {{/ui-dropdown}}
                         {{/if}}

--- a/app/components/ui/select-data-modal/component.js
+++ b/app/components/ui/select-data-modal/component.js
@@ -85,7 +85,7 @@ export default Component.extend({
         },
 
         addSelectedData() {
-            this.addSelectedData.call(this, this.get('files'), this.get('folders'));
+            this.addSelectedData.call(this, this.get('datasets'), this.get('files'), this.get('folders'));
         },
 
         removeSelectedData() {
@@ -221,7 +221,7 @@ export default Component.extend({
         });
     },
 
-    addSelectedData(files, folders) {
+    addSelectedData(datasets, files, folders) {
         const self = this;
         const add = f => {
           if (f.selected) {
@@ -232,6 +232,7 @@ export default Component.extend({
                 }
             }
         }
+        datasets.forEach(add);
         files.forEach(add);
         folders.forEach(add);
     },

--- a/app/components/ui/select-data-modal/component.js
+++ b/app/components/ui/select-data-modal/component.js
@@ -149,11 +149,6 @@ export default Component.extend({
     },
 
     dblClick(target) {
-        // HACK: Standard endpoints use "_modelType", /dataset uses "modelType"
-        if (!target._modelType && target.modelType) {
-            target._modelType = target.modelType;
-        }
-        
         if (!target || !target._modelType || (target._modelType !== 'folder' && target._modelType !== 'dataset')) {
             throw new Error('[select-data-modal] Cannot open. Not a folder or dataset.');
         }

--- a/app/components/ui/select-data-modal/component.js
+++ b/app/components/ui/select-data-modal/component.js
@@ -19,7 +19,7 @@ export default Component.extend({
     selectedMenuIndex: 0,
     dataSources: A([
         O({ name: 'WholeTale Catalog' }),
-        //O({ name: 'Tale Workspaces' })
+        //O({ name: 'My Data' })
     ]),
     selectedDataSource: O({}),
 
@@ -131,13 +131,17 @@ export default Component.extend({
         let adapterOptions = { queryParams: { limit: "0" } };
 
         const self = this;
-        return store.query('folder', { parentId, parentType, adapterOptions }).then(dataFolder => {
-            let dataFolderId = dataFolder.content[0].id;
+        return store.query('dataset', { adapterOptions }).then(datasets => {
+            let catalogId = parentId;
             let parentCollection = parentType;
-            self.set('rootFolderId', dataFolderId);
-            self.set('currentFolder', O({ id: dataFolderId, _modelType: 'folder', parentCollection, parentId }));
+            self.set('rootFolderId', catalogId);
+            self.set('loading', false);
+            self.set('datasets', A(datasets));
+            self.set('folders', A([]));
+            self.set('files', A([]));
+            self.set('currentFolder', O({ id: catalogId, _modelType: 'folder', parentCollection, parentId }));
 
-            return self.loadFolder.call(self, dataFolderId, 'folder');
+            //return self.loadFolder.call(self, catalogId, 'folder');
         }).catch(e => {
             self.set('loadError', true);
             self.set('loadingMessage', 'Failed to load registered data. Please try again');
@@ -145,8 +149,13 @@ export default Component.extend({
     },
 
     dblClick(target) {
-        if (!target || !target._modelType || target._modelType !== 'folder') {
-            throw new Error('[select-data-modal] Cannot open. Not a folder.');
+        // HACK: Standard endpoints use "_modelType", /dataset uses "modelType"
+        if (!target._modelType && target.modelType) {
+            target._modelType = target.modelType;
+        }
+        
+        if (!target || !target._modelType || (target._modelType !== 'folder' && target._modelType !== 'dataset')) {
+            throw new Error('[select-data-modal] Cannot open. Not a folder or dataset.');
         }
 
         this.set('currentFolder', target);
@@ -163,7 +172,7 @@ export default Component.extend({
         target.set('selected', selected);
     },
 
-    goBack(currentFolder) {
+    goBack(currentFolder, adapterOptions = { queryParams: { limit: "0" } }) {
         this.set('loading', true);
         this.set('loadError', false);
         this.set('loadingMessage', 'Preparing Files');
@@ -174,13 +183,24 @@ export default Component.extend({
         let parentType = currentFolder.parentCollection;
 
         const self = this;
-        return store.find('folder', parentId).then(parent => {
-            self.set('currentFolder', parent);
-            return self.loadFolder.call(self, parentId, parentType);
-        }).catch(e => {
-            self.set('loadError', true);
-            self.set('loadingMessage', 'Failed to load registered data. Please try again');
-        });
+        if (parentId == null || parentId == this.get('rootFolderId')) {
+            return store.query('dataset', adapterOptions).then(datasets => {
+                let catalogId = this.get('rootFolderId');
+                self.set('loading', false);
+                self.set('currentFolder', O({ id: catalogId, _modelType: 'folder', parentType, catalogId }));
+                self.set('datasets', A(datasets));
+                self.set('folders', A([]));
+                self.set('files', A([]));
+            });
+        } else {
+            return store.find('folder', parentId).then(parent => {
+                self.set('currentFolder', parent);
+                return self.loadFolder.call(self, parentId, parentType);
+            }).catch(e => {
+                self.set('loadError', true);
+                self.set('loadingMessage', 'Failed to load registered data. Please try again');
+            });
+        }
     },
 
     loadFolder(parentId, parentType, adapterOptions = { queryParams: { limit: "0" } }) {
@@ -194,6 +214,7 @@ export default Component.extend({
 
         const self = this;
         return Promise.all([fetchFolders, fetchFiles]).then(([folders, files]) => {
+            self.set('datasets', A([]));
             self.set('folders', A(folders));
             self.set('files', A(files));
             self.set('loading', false);

--- a/app/components/ui/select-data-modal/template.hbs
+++ b/app/components/ui/select-data-modal/template.hbs
@@ -36,27 +36,36 @@
                                             <i class="long alternate blue left arrow icon"></i>{{currentFolder.name}}
                                         </td>
                                     </tr>
+                                    {{#each folders as | folder |}}
+                                        <tr class="{{if folder.selected 'selected-row'}}"
+                                            {{action 'dblClick' folder on='doubleClick'}}
+                                            {{action 'onClick' folder on='click'}}>
+                                            <td class="collapsing noselect">
+                                                <i class="folder icon"></i>{{folder.name}}
+                                            </td>
+                                        </tr>
+                                    {{/each}}
+                                    {{#each files as | file |}}
+                                        <tr class="{{if file.selected 'selected-row'}}">
+                                            <td class="collapsing noselect" {{action 'onClick' file on='click'}}>
+                                                <i class="file icon"></i>{{file.name}}
+                                            </td>
+                                        </tr>
+                                    {{/each}}
                                 {{else}}
                                     <tr>
                                         <td class="ui sub header collapsing noselect">Catalog</td>
                                     </tr>
+                                    {{#each datasets as | dataset |}}
+                                        <tr class="{{if dataset.selected 'selected-row'}}"
+                                            {{action 'dblClick' dataset on='doubleClick'}}
+                                            {{action 'onClick' dataset on='click'}}>
+                                            <td class="collapsing noselect">
+                                                <i class="folder icon"></i>{{dataset.name}}
+                                            </td>
+                                        </tr>
+                                    {{/each}}
                                 {{/if}}
-                                {{#each folders as | folder |}}
-                                    <tr class="{{if folder.selected 'selected-row'}}"
-                                        {{action 'dblClick' folder on='doubleClick'}}
-                                        {{action 'onClick' folder on='click'}}>
-                                        <td class="collapsing noselect">
-                                            <i class="folder icon"></i>{{folder.name}}
-                                        </td>
-                                    </tr>
-                                {{/each}}
-                                {{#each files as | file |}}
-                                    <tr class="{{if file.selected 'selected-row'}}">
-                                        <td class="collapsing noselect" {{action 'onClick' file on='click'}}>
-                                            <i class="file icon"></i>{{file.name}}
-                                        </td>
-                                    </tr>
-                                {{/each}}
                             </tbody>
                         </table>
                     {{/if}}

--- a/app/components/ui/select-data-modal/template.hbs
+++ b/app/components/ui/select-data-modal/template.hbs
@@ -61,7 +61,11 @@
                                             {{action 'dblClick' dataset on='doubleClick'}}
                                             {{action 'onClick' dataset on='click'}}>
                                             <td class="collapsing noselect">
-                                                <i class="folder icon"></i>{{dataset.name}}
+                                                {{#if (eq dataset._modelType 'item')}}
+                                                    <i class="file icon"></i>{{dataset.name}}
+                                                {{else}}
+                                                    <i class="folder icon"></i>{{dataset.name}}
+                                                {{/if}}
                                             </td>
                                         </tr>
                                     {{/each}}

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -95,6 +95,11 @@ export default Component.extend({
         }
 
         this.set('fileBreadCrumbs', state.getCurrentFileBreadcrumbs()); // new collection, reset crumbs
+        
+        // Resync data when tale model changes
+        this.addObserver('model', function() {
+            this.resync();
+        });
     },
 
     showSuccessfulCopyNotification(notifier, copier, gerund) {

--- a/app/models/dataset.js
+++ b/app/models/dataset.js
@@ -1,14 +1,14 @@
-import Ember from 'ember';
 import DS from 'ember-data';
 
 export default DS.Model.extend({
   _id: DS.attr('string'),
+  _modelType: DS.attr('string'),
   created: DS.attr('date'),
   creatorId: DS.attr('string'),
   description: DS.attr('string'),
   identifier: DS.attr('string'),
-  modelType: DS.attr('string'),
   name: DS.attr('string'),
   provider: DS.attr('string'),
-  size: DS.attr('number')
+  size: DS.attr('number'),
+  updated: DS.attr('date'),
 });


### PR DESCRIPTION
* Fixes #357

## How to Test
1. Sync your girder_wholetale with master, checkout and run this dashboard branch locally, and rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create and Launch a Tale, if you haven't already
4. Register a new Dataset - this is important with the addition of https://github.com/whole-tale/girder_wholetale/pull/205
5. Navigate to the Run view by clicking a "Launched Tale" in the panel on the right
6. Click the "Files" tab beneath the Tale header
    * You should be presented with a directory-browser with some navs on the left side
7. On the left, choose the "External Data" nav
    * You should be presented with a list containing any "External Data" added to this tale
8. Click the (+) button at the top-right
    * You should be presented with the "Select Data" modal
    * The "WholeTale Catalog" nav on the left should be selected by default - the modal should list the full contents of the WholeTale Catalog (GET `/dataset`) in the left pane
    * You should now see an option for "My Data" in the navs on the left
    * Full datasets should be selectable in the same way as the folders and files beneath them
9. Click the "My Data" nav on the left
    * The view should filter to show only those datasets that the currently logged-in user registered
10. On the top navbar, click "Manage"
    * You should be presented with a directory-browser with some navs on the left side
11. On the left, choose the "Data" nav
    * You should be presented with a list containing only the datasets in the WholeTale Catalog that the user has registered
12. Click on a dataset
    * You should be shown the contents of that dataset
    * If loading takes too long, you should see a loading spinner appear in the directory-browser, indicating that the clicked folder contents are loading
13. Click the dropdown arrow to the right of a file or folder
    * You should see only an option for "Download"
14. Click the breadcrumb "Data"
    * You should be brought back to the top-level list of the user's registered datasets
15. Click the dropdown arrow to the right of a dataset
    * You should see an option for "Download"
    * You should see an option for "Remove" - NOTE: since there is currently no `DELETE /datasets/:id` endpoint, this is not yet functional
    