### PR TITLE
Uncomment 'Remove' button, wire up to new DELETE /dataset/:id endpoint

### DIFF
--- a/app/components/ui/files/directory-browser/component.js
+++ b/app/components/ui/files/directory-browser/component.js
@@ -183,6 +183,23 @@ export default Component.extend({
           self.set('loadingMessage', 'Failed to load home folder content. Please try again');
       });
     },
+    
+    removeDataset(id) {
+      const self = this;
+      this.set('loading', true);
+      this.set('loadError', false);
+      this.get('store').findRecord('dataset', id, { backgroundReload: false }).then(dataset => {
+        console.log("Dataset reference found... deleting:", dataset);
+        dataset.destroyRecord().then(() => {
+          self.set('loading', false);
+          self.set('loadError', true);
+        });
+      }).catch((err) => {
+        console.log("Error:", err);
+        self.set('loading', false);
+        self.set('loadError', true);
+      });
+    },
 
     remove(file) {
       this.get('internalState').removeFolderFromRecentFolders(file.id);

--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -40,9 +40,8 @@
                                 <a class="item" href="{{apiUrl}}/{{item._modelType}}/{{item.id}}/download?contentDisposition=attachment">
                                     <i class="download icon"></i> Download
                                 </a>
-                                {{!-- FIXME: There is not yet a DELETE /dataset endpoint --}}
-                                <a class="item" style="cursor:not-allowed;">
-                                    <i class="trash icon"></i> Remove {{!-- {{action "remove" item}} --}}
+                                <a class="item" href="#" {{action "removeDataset" item.id}}>
+                                    <i class="trash icon"></i> Remove
                                 </a>
                             </div>
                         {{/ui-dropdown}}


### PR DESCRIPTION
### Problem
User cannot DELETE their reference to a registered dataset from the UI

### Approach
Integrating with @Xarthisius' new DELETE `/dataset/:id` endpoint made this easy

### How to Test
NOTE: Requires https://github.com/whole-tale/girder_wholetale/pull/235 to test

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Manage > Data
4. Register two new Datasets
5. Check the output of `GET /dataset?myData=true` 
    * Confirm that the datasets are registered the the current user
6. Right-click one of the two new Datasets you just added and click "Remove"
    * You should see the Dataset is removed from the view
7. Check the output of `GET /dataset?myData=false` 
    * Confirm that both datasets are still returned
8. Check the output of `GET /dataset?myData=true`
    * Confirm that only one Dataset remains
    * Confirm that the remaining Dataset was the one that was NOT deleted as a part of step 6 