### PR TITLE
Ensure readthedocs links always open in a new tab

### DIFF
--- a/app/components/dashboard/browse/left-panel/template.hbs
+++ b/app/components/dashboard/browse/left-panel/template.hbs
@@ -4,7 +4,7 @@
             {{!-- <img src="images/wholetale_logo_sm.png" /> --}}
             Browse Tales <span class="subtitle">Launch to add to Launched Tales list</span>
             <i class="fas fa-expand right" style="cursor: pointer;" {{action 'toggleFullscreen'}}></i>
-            <a href="https://wholetale.readthedocs.io/en/stable/users_guide/browse.html">
+            <a href="https://wholetale.readthedocs.io/en/stable/users_guide/browse.html" target="_blank">
               <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
             </a>
         </h2>

--- a/app/components/dashboard/compose/left-panel/template.hbs
+++ b/app/components/dashboard/compose/left-panel/template.hbs
@@ -7,7 +7,7 @@
       <span class="subtitle">
         Create a new Tale by pairing a compute environment with a dataset
       </span>
-      <a href="https://wholetale.readthedocs.io/users_guide/compose.html">
+      <a href="https://wholetale.readthedocs.io/users_guide/compose.html" target="_blank">
         <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
       </a>
     </h2>

--- a/app/components/dashboard/manage/left-panel/template.hbs
+++ b/app/components/dashboard/manage/left-panel/template.hbs
@@ -2,7 +2,7 @@
     <div class="wt paddleboard">
         <h2>
           <i class="far fa-hdd"></i> Data <span style="font-style:italic;">Import or link data to use in Tales</span>
-          <a href="https://wholetale.readthedocs.io/en/stable/users_guide/manage.html">
+          <a href="https://wholetale.readthedocs.io/en/stable/users_guide/manage.html" target="_blank">
             <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
           </a>
         </h2>

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -45,7 +45,7 @@
                         {{#click-outside action=(action (mut displayTaleInstanceMenu) false)}}
                             <div class="tale-instance-menu">
                                 <div class="ui vertical left menu transition">
-                                    <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/run.html">
+                                    <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/run.html" target="_blank">
                                         Read the docs <div class="ui label transparent"><i class="fas fa-book"></i></div>
                                     </a>
                                     {{#if readyToReleaseFeature}}

--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -94,7 +94,7 @@
                             {{/link-to}}
                         </li>
                         <li class="bm-menu-item">
-                            <a href="https://wholetale.readthedocs.io/en/stable/users_guide/index.html">
+                            <a href="https://wholetale.readthedocs.io/en/stable/users_guide/index.html" target="_blank">
                                 <i class="info circle black icon"></i> User Guide
                             </a>
                         </li>


### PR DESCRIPTION
### Problem
When clicking a RTD link in the WholeTale Dashboard, the user's current tab is replaced. It would be better if the docs were opened in a new tab.

Fixes #385

NOTE: this can also be remedied by simply clicking the middle mouse button instead of left clicking on the link

### Approach
Add `target="_blank"` anywhere it is missing if readthedocs appears


### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Verify that the following links now open in a new tab every time:
    * Browse > (i) icon
    * Manage > (i) icon
    * Compose > (i) icon
    * Run > "..." on `wt-paddleboard` > Read the docs
    * Header (is this the Navbar?) > (i) icon