### PR TITLE
Disallow user from accidentally selecting an entire tale workspace

### DIFF
--- a/app/components/ui/files/workspaces-data-modal/component.js
+++ b/app/components/ui/files/workspaces-data-modal/component.js
@@ -119,24 +119,35 @@ export default Component.extend({
 
     dblClick(target) {
         if (!target || !target._modelType || target._modelType !== 'folder') {
-            throw new Error('[select-data-modal] Cannot open. Not a folder.');
+            // Only allow the user to double-click folders
+            //throw new Error('[select-data-modal] Cannot open. Not a folder.');
+            return;
         }
-
-        this.set('currentFolder', target);
         
-        let parentCollection = 'folder';
-        let parentId = target.get('id');
-
-        const self = this;
-        return this.loadFolder.call(this, parentId, parentCollection).catch(e => {
-            self.set('loadError', true);
-            self.set('loadingMessage', 'Failed to load registered data. Please try again');
-        });
+        this.set('currentFolder', target);
+        this.get('openFolder')(target, this);
     },
 
     onClick(target) {
-        let selected = !target.get('selected');
-        target.set('selected', selected);
+        if (this.get('rootFolderId') == this.get('currentFolder').get('id')) {
+            // Only allow the user to select files and folders (not an entire Workspace)
+            //throw new Error('[select-data-modal] Cannot select. Not a folder or item.');
+            this.set('currentFolder', target);
+            this.get('openFolder')(target, this);
+        } else {
+            let selected = !target.get('selected');
+            target.set('selected', selected);
+        }
+    },
+    
+    openFolder(target, self = this) {
+        let parentCollection = 'folder';
+        let parentId = target.get('id');
+
+        return self.loadFolder.call(self, parentId, parentCollection).catch(e => {
+            self.set('loadError', true);
+            self.set('loadingMessage', 'Failed to load registered data. Please try again');
+        });
     },
 
     goBack(currentFolder, adapterOptions = { queryParams: { limit: "0" } }) {

--- a/app/components/ui/files/workspaces-data-modal/template.hbs
+++ b/app/components/ui/files/workspaces-data-modal/template.hbs
@@ -36,7 +36,7 @@
                                 {{#if (eq rootFolderId currentFolder.id)}}
                                     <th class="ui sub header collapsing noselect">
                                         {{#if (eq currentFolder.id internalState.workspaceRootId)}}
-                                            Workspace Root Folder
+                                            Select a Tale
                                         {{else}}
                                             Home Folder
                                         {{/if}}
@@ -52,18 +52,23 @@
                             <tbody>
                                 {{#each folders as | folder |}}
                                     {{#unless (and (eq taleId folder.meta.taleId) (eq rootFolderId currentFolder.id))}}
-                                        <tr class="{{if folder.selected 'selected-row'}}"
+                                        <tr class="clickable {{if folder.selected 'selected-row'}}"
                                             {{action 'dblClick' folder on='doubleClick'}}
-                                            {{action 'onClick' folder on='click'}}>
-                                            <td class="collapsing noselect">
+                                            {{action 'onClick' folder on='click'}}
+                                            title={{if (eq rootFolderId currentFolder.id) 
+                                                    'Click to open a Tale Workspace' 
+                                                    'Click to select a folder, double-click to open it'}}>
+                                            <td class="collapsing noselect clickable">
                                                 <i class="folder icon"></i>{{truncate-name folder.name}}
                                             </td>
                                         </tr>
                                     {{/unless}}
                                 {{/each}}
                                 {{#each files as | file |}}
-                                    <tr class="{{if file.selected 'selected-row'}}">
-                                        <td class="collapsing noselect" {{action 'onClick' file on='click'}}>
+                                    <tr class="clickable {{if file.selected 'selected-row'}}"
+                                        {{action 'onClick' file on='click'}}
+                                        title="Click to select a file">
+                                        <td class="collapsing noselect ">
                                             <i class="file icon"></i>{{file.name}}
                                         </td>
                                     </tr>


### PR DESCRIPTION
## Problem
Currently, the user can "Select" and entire workspace on the Tale Workspaces modal. While we disallow submission at the root, I expect that they could drill down a folder (with the entire workspace still selected) and submit it just the same.

## Approach
* Changed header at root level on Tale Workspaces modal from "Workspace Root Folder" to "Select a Tale"
* Provide a Pointer over clickable folders/files in the Tale Workspaces modal
* Single-click on a workspace works the same as a double-click on a folder, but prevents the user from "Selecting" the entire workspace
* Added tooltips to folders/files in the Tale Workspaces modal

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Compose and launch a few Tales, if you haven't already
4. Add some files/folders to your Tale Workspaces, if you haven't already
5. Navigate to Run > Files > Tale Workspaces
6. Click (+) at the top-right of the panel
    * You should be presented with the Tale Workspaces modal
    * You should see all existing Tales here, listed by name
7. Hover your mouse over a Tale name for 5+ seconds
    * A tooltip should display, telling you how you can interact with the workspace
8. Click on a workspace
    * You should be brought into the folder for that Workspace
    * You should NOT need to double-click for this to happen
9. Hover over a folder
    * A tooltip should display, telling you how you can interact with the folder
10. Single-click on a folder
    * The folder should be selected
11. Double-click on a folder
    * You should be brought into the double-clicked folder
12. Hover over a folder
    * A tooltip should display, telling you how you can interact with the file
13. Single-click on a file
    * The folder should be selected
14. Double-click on a file
    * You should be brought into the double-clicked folder