### PR TITLE
Refilter Tale list after deleting a Tale

### DIFF
--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -233,6 +233,7 @@ export default Ember.Component.extend({
         // refresh
         component.updateModels(component, component.get('models'));
         component.set('selectedTale', undefined);
+        component.setFilter();
       });
 
       return false;


### PR DESCRIPTION
### Problem
Fixes #390 

### Approach
Just needed to call `setFilter()` after resyncing Tale data

### How to Test
Prerequisite: at least one Tale has been created in the system that does not belong to you

1. Compose a Tale
2. Navigate to "Browse" and filter to "Mine"
    * You should see that Tales you do not own are hidden
3. Delete the Tale that you own
    * You should see that Tales you do not own are still hidden