### PR TITLE
Refilter with myData when calling goBack in select-data-modal

### DIFF
--- a/app/components/ui/select-data-modal/component.js
+++ b/app/components/ui/select-data-modal/component.js
@@ -186,14 +186,7 @@ export default Component.extend({
 
         const self = this;
         if (parentId == null || parentId == this.get('rootFolderId')) {
-            return store.query('dataset', adapterOptions).then(datasets => {
-                let catalogId = this.get('rootFolderId');
-                self.set('loading', false);
-                self.set('currentFolder', O({ id: catalogId, _modelType: 'folder', parentType, catalogId }));
-                self.set('datasets', A(datasets));
-                self.set('folders', A([]));
-                self.set('files', A([]));
-            });
+            return this.requeryDatasets();
         } else {
             return store.find('folder', parentId).then(parent => {
                 self.set('currentFolder', parent);


### PR DESCRIPTION
### Problem
Fixes #389 

### Approach
We were not passing the `myData` parameter to `GET /dataset` in this case - pass this parameter when calling `goBack()`

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Launch a Tale
3. Navigate to Run > Files > External Data > +  to open the Select Data modal
4. Select My Data
    * You should see the list is filtered to show only datasets that you (the user) have registered
5. Browse into a dataset
6. Select "<-" to return to the My Data
    * You should see the list still shows only datasets that you (the user) have registered

