### PR TITLE
Fixes #392: correct user_guide link for Compose

### DIFF
--- a/app/components/dashboard/compose/left-panel/template.hbs
+++ b/app/components/dashboard/compose/left-panel/template.hbs
@@ -7,7 +7,7 @@
       <span class="subtitle">
         Create a new Tale by pairing a compute environment with a dataset
       </span>
-      <a href="https://wholetale.readthedocs.io/users_guide/compose.html" target="_blank">
+      <a href="https://wholetale.readthedocs.io/en/stable/users_guide/compose.html" target="_blank">
         <i class="fas fa-info-circle right" style="cursor: pointer; padding-right: 0.3em"></i>
       </a>
     </h2>


### PR DESCRIPTION
### Problem
Fixes #392 

### How to Test
1. Copy and paste old link from this diff
    * Results in a 404
2. Copy and paste new link from this diff
    * Results in correct user guide page