### PR TITLE
Fixes #394: Fix text color on Tale Browser's Delete Tale modal

### DIFF
--- a/app/components/ui/delete-modal/template.hbs
+++ b/app/components/ui/delete-modal/template.hbs
@@ -4,7 +4,7 @@
     </div>
     <div class="image content">
         <div class="description">
-            <p>This will permanently delete the '{{truncate-name model.name}}' {{modelType}}. Continue?</p>
+            <p style="color: #000 !important;">This will permanently delete the '{{truncate-name model.name}}' {{modelType}}. Continue?</p>
         </div>
     </div>
     <div class="actions">


### PR DESCRIPTION
### Problem
Fixes #394 

### Approach
I went ahead and hard-coded the text color in here, since we seem to have some issues with inheriting from parent between the two views where this is used

### How to Test
1. Checkout and run this branch locally
2. Login to the WholeTale Dashboard and navigate to "Browse"
3. Click the Delete button
    * The `delete-modal` should appear
    * You should see the specified text now appears in the modal