### PR TITLE
[Firefox] Set a max-height on Select Data content

### DIFF
--- a/app/components/ui/select-data-modal/template.hbs
+++ b/app/components/ui/select-data-modal/template.hbs
@@ -18,7 +18,7 @@
             </div>
 
             <div class="seven wide column">
-                <div class="ui segment" style="overflow-y:scroll;max-height:500px;">
+                <div class="ui segment" style="overflow-y:scroll;max-height:600px;">
                     <button class="ui very basic right labeled icon button" {{action 'addSelectedData'}}><i class="angle double right icon"></i>Add
                         Selected</button>
                     {{#if loading}}

--- a/app/components/ui/select-data-modal/template.hbs
+++ b/app/components/ui/select-data-modal/template.hbs
@@ -18,7 +18,7 @@
             </div>
 
             <div class="seven wide column">
-                <div class="ui segment" style="overflow-y:scroll;">
+                <div class="ui segment" style="overflow-y:scroll;max-height:500px;">
                     <button class="ui very basic right labeled icon button" {{action 'addSelectedData'}}><i class="angle double right icon"></i>Add
                         Selected</button>
                     {{#if loading}}


### PR DESCRIPTION
### Problem
Fixes #399

As reported in #399, Firefox does not support the `intrinsic-width` browser feature: https://caniuse.com/#feat=intrinsic-width

I believe this is why Firefox seem to be ignoring the `style="height: -mox-available"` to fit content to the height of the view.

### Approach
Hard-code a `max-height` on this modal content to avoid it from extending off the screen.

NOTE: This does not seem to have any adverse effects on Chrome or other browsers which correctly use the browser's fill attributes (e.g. `height: -webkit-fill-available`)

### How to Test
Prerequisite: Use Firefox browser, register many datasets?

1. Checkout and run this branch locally
2. Launch a Tale
3. Navigate to Run > Files > External Data > (+) to open select data modal
    * You should see that the modal no longer extends off the screen
    * Side-effect: You may notice that the background behind the modal looks odd, this is ok