### PR TITLE
Reordered navs on Select Data modal

### DIFF
--- a/app/components/ui/select-data-modal/component.js
+++ b/app/components/ui/select-data-modal/component.js
@@ -18,8 +18,8 @@ export default Component.extend({
 
     selectedMenuIndex: 0,
     dataSources: A([
-        O({ name: 'WholeTale Catalog' }),
-        O({ name: 'My Data' })
+        O({ name: 'My Data' }),
+        O({ name: 'WholeTale Catalog' })
     ]),
     selectedDataSource: O({}),
 


### PR DESCRIPTION
### Problem
User can be overwhelmed by too many datasets in the WholeTale Catalog

Fixes #401

### Approach
Filter to "My Data" by default by swapping the order of the navs - first nav is selected by default

### How to Test
1. Checkout and run this branch locally
2. Login to the Dashboard and Launch a Tale
3. Navigate to Run > Files > External Data > (+) to open the Select Data modal
    * You should see that "My Data" is selected by default