### PR TITLE
Move tooltip on Registration modal back into view

### DIFF
--- a/app/components/ui/files/registration-modal/template.hbs
+++ b/app/components/ui/files/registration-modal/template.hbs
@@ -8,7 +8,7 @@
                         Reference URI
                         <i class="info circle grey icon"></i>
                         <div class="floating ui basic blue label hidden" 
-                             style="left:1em !important; top: -2em !important; padding:8px; background: none !important; background-color: transparent !important;"
+                             style="left:3em !important; top: 3em !important; padding:8px; background: none !important; background-color: transparent !important;"
                              id="info-data-content">The HTTP URL, DOI, or dataId</div>
                     </label>
                     {{input type="text" id="searchbox" value=searchDataId}}


### PR DESCRIPTION
### Problem
Tooltip on the Data Registration modal extends off the screen

Fixes #400

### Approach
Tooltip is heavily manual and thoroughly hard-coded - Move it slightly down and slightly to the right

NOTE: an easy yet hacky fix... but do we even need a tooltip here? There is another description directly beneath the input

### How to Test
1. Checkout and run this branch locally
2. Login to the Dashboard
3. Navigate to Manage > Data > (+) to open the Data Registration modal
4. Hover over the (i) near the first input
    * You should see that the tooltip now stays on the page

