### PR TITLE
Disable Run > Files > Tale Workspaces UI if insufficient Tale access

### DIFF
--- a/app/components/ui/files/bread-crumbs/template.hbs
+++ b/app/components/ui/files/bread-crumbs/template.hbs
@@ -2,7 +2,12 @@
     <div class="ui large breadcrumb">
         <a class="section {{if justDescription 'bold'}}" {{action "navClicked" currentNav}}> {{#if justDescription}} {{currentNav.displayName}} {{else}} {{currentNav.name}} {{/if}}</a>
         {{#if justDescription}}
-            <i class="fas fa-plus-circle icon blue large" onclick={{action 'triggerBreadcrumbAction' currentNav.name}}></i>
+            {{#if (and (lt model.tale._accessLevel 1) (eq currentNav.name 'workspace'))}}
+                <i class="fas fa-plus-circle icon blue large disabled" disabled style="cursor:not-allowed !important;" 
+                    data-tooltip="You do not have write access to this Tale." data-inverted=""></i>
+            {{else}}
+                <i class="fas fa-plus-circle icon blue large" onclick={{action 'triggerBreadcrumbAction' currentNav.name}}></i>
+            {{/if}}
             {{#if displayFoldersMenu}}
                 {{#click-outside action=(action (mut displayFoldersMenu) false)}}
                     <div class="folder-menu">

--- a/app/components/ui/files/bread-crumbs/template.hbs
+++ b/app/components/ui/files/bread-crumbs/template.hbs
@@ -2,9 +2,8 @@
     <div class="ui large breadcrumb">
         <a class="section {{if justDescription 'bold'}}" {{action "navClicked" currentNav}}> {{#if justDescription}} {{currentNav.displayName}} {{else}} {{currentNav.name}} {{/if}}</a>
         {{#if justDescription}}
-            {{#if (and (lt model.tale._accessLevel 1) (eq currentNav.name 'workspace'))}}
-                <i class="fas fa-plus-circle icon blue large disabled" disabled style="cursor:not-allowed !important;" 
-                    data-tooltip="You do not have write access to this Tale." data-inverted=""></i>
+            {{#if (and (lt model.tale._accessLevel 1) (eq currentNav.command 'workspace'))}}
+                <i class="fas fa-plus-circle icon blue large disabled" disabled style="cursor:not-allowed !important;"></i>
             {{else}}
                 <i class="fas fa-plus-circle icon blue large" onclick={{action 'triggerBreadcrumbAction' currentNav.name}}></i>
             {{/if}}

--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -85,22 +85,28 @@
                                 </a>
                                 <i class="dropdown icon"></i>
                                 <div class="menu">
-                                    <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
-                                    {{#if (eq currentNav.command 'user_data')}}
-                                        <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
+                                    {{#if (and (eq currentNav.command 'workspace') (lt model.tale._accessLevel 1))}}
+                                        <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                        <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
                                                 class="download icon"></i> Download</a>
                                     {{else}}
-                                        <a class="item" {{action "rename" item}}><i class="write square icon"></i>
-                                            Rename...</a>
-                                        {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a>--}}
-                                        {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
-                                            <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                        <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
+                                        {{#if (eq currentNav.command 'user_data')}}
+                                            <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
+                                                    class="download icon"></i> Download</a>
                                         {{else}}
-                                            <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
+                                            <a class="item" {{action "rename" item}}><i class="write square icon"></i>
+                                                Rename...</a>
+                                            {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a>--}}
+                                            {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
+                                                <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                            {{else}}
+                                                <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
+                                                <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
+                                            {{/if}}
+                                            <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
+                                                    class="download icon"></i> Download</a>
                                         {{/if}}
-                                        <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
-                                                class="download icon"></i> Download</a>
-                                        <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                     {{/if}}
                                 </div>
                             {{/ui-dropdown}}
@@ -133,7 +139,11 @@
                                 </a>
                                 <i class="dropdown icon"></i>
                                 <div class="menu">
-                                    {{#if (eq currentNav.command 'user_data')}}
+                                    {{#if (and (eq currentNav.command 'workspace') (lt model.tale._accessLevel 1))}}
+                                        <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                        <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
+                                                class="download icon"></i> Download</a>
+                                    {{else if (eq currentNav.command 'user_data')}}
                                         <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
                                                 class="download icon"></i> Download</a>
                                     {{else}}

--- a/app/components/ui/files/folder-navigator/template.hbs
+++ b/app/components/ui/files/folder-navigator/template.hbs
@@ -2,7 +2,7 @@
     <div class="sixteen wide tablet computer only column">
         <div class="ui vertical mini compact menu">
             {{#each navs as |nav|}}
-                {{#unless (and useIcons (eq nav.command "workspace") )}}
+                {{#unless (or (and useIcons (eq nav.command "workspace")) (and (gt model.tale._accessLevel -1) (eq nav.command "workspace")))}}
                     <div class="sixteen menu-item clickable">
                         {{#if (and (eq currentNavCommand nav.command) nav.allowUpload)}}
                             <a class="active item" {{action "navClicked" nav}}>
@@ -44,14 +44,25 @@
                                 </div>
                             </a>
                         {{else}}
-                            <a class="item" {{action "navClicked" nav}}>
-                                <div style="padding-left: 1rem; padding-top: 4px;">
-                                    <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
-                                </div>
-                                <div class="icon-wrapper">
-                                    {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}}  {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
-                                </div>
-                            </a>
+                            {{#if (and (lt model.tale._accessLevel 0) (eq nav.command "workspace"))}}
+                                <a class="item disabled" disabled style="cursor:not-allowed !important;" data-tooltip="You do not have read access to this Tale's Workspace." data-inverted="">
+                                    <div style="padding-left: 1rem; padding-top: 4px;">
+                                        <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
+                                    </div>
+                                    <div class="icon-wrapper">
+                                        {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}}  {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
+                                    </div>
+                                </a>
+                            {{else}}
+                                 <a class="item" {{action "navClicked" nav}}>
+                                    <div style="padding-left: 1rem; padding-top: 4px;">
+                                        <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
+                                    </div>
+                                    <div class="icon-wrapper">
+                                        {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}}  {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
+                                    </div>
+                                </a>
+                            {{/if}}
                         {{/if}}
                     </div>
                 {{/unless}}

--- a/app/components/ui/files/folder-navigator/template.hbs
+++ b/app/components/ui/files/folder-navigator/template.hbs
@@ -2,7 +2,7 @@
     <div class="sixteen wide tablet computer only column">
         <div class="ui vertical mini compact menu">
             {{#each navs as |nav|}}
-                {{#unless (or (and useIcons (eq nav.command "workspace")) (and (gt model.tale._accessLevel -1) (eq nav.command "workspace")))}}
+                {{#unless (or (and useIcons (eq nav.command "workspace")))}}
                     <div class="sixteen menu-item clickable">
                         {{#if (and (eq currentNavCommand nav.command) nav.allowUpload)}}
                             <a class="active item" {{action "navClicked" nav}}>
@@ -44,7 +44,7 @@
                                 </div>
                             </a>
                         {{else}}
-                            {{#if (and (lt model.tale._accessLevel 0) (eq nav.command "workspace"))}}
+                            {{#if (and (and (lt model.tale._accessLevel 1) (eq model.tale.public 'false')) (eq nav.command "workspace"))}}
                                 <a class="item disabled" disabled style="cursor:not-allowed !important;" data-tooltip="You do not have read access to this Tale's Workspace." data-inverted="">
                                     <div style="padding-left: 1rem; padding-top: 4px;">
                                         <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
@@ -114,14 +114,25 @@
                                 </div>
                             </a>
                         {{else}}
-                            <a class="item" {{action "navClicked" nav}}>
-                                <div style="padding-left: 1rem; padding-top: 4px;">
-                                    <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
-                                </div>
-                                <div class="icon-wrapper">
-                                    {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}} {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
-                                </div>
-                            </a>
+                            {{#if (and (and (lt model.tale._accessLevel 1) (eq model.tale.public 'false')) (eq nav.command "workspace"))}}
+                                <a class="item disabled" disabled {{action "navClicked" nav}} data-tooltip="You do not have read access to this Tale's Workspace." data-inverted="">
+                                    <div style="padding-left: 1rem; padding-top: 4px;">
+                                        <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
+                                    </div>
+                                    <div class="icon-wrapper">
+                                        {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}} {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
+                                    </div>
+                                </a>    
+                            {{else}}
+                                <a class="item" {{action "navClicked" nav}}>
+                                    <div style="padding-left: 1rem; padding-top: 4px;">
+                                        <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
+                                    </div>
+                                    <div class="icon-wrapper">
+                                        {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}} {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
+                                    </div>
+                                </a>
+                            {{/if}}
                         {{/if}}
                     </div>
                 {{/unless}}

--- a/app/components/ui/tale-tab-files/template.hbs
+++ b/app/components/ui/tale-tab-files/template.hbs
@@ -40,6 +40,7 @@
         <div class="ui collapsable grid">
             <div class="sixteen wide right aligned column">
                 {{ui/files/directory-browser 
+                    model=model
                     currentNav=currentNav
                     sessionList=fileData.sessionContents
                     folderList=fileData.folderContents

--- a/app/components/ui/tale-tab-files/template.hbs
+++ b/app/components/ui/tale-tab-files/template.hbs
@@ -8,6 +8,7 @@
         <div class="eleven wide column">
             {{ui/files/bread-crumbs 
                 currentNav=currentNav
+                model=model
                 currentBreadCrumb=currentBreadCrumb
                 fileBreadCrumbs=fileBreadCrumbs
                 openUploadDialog="openUploadDialog"
@@ -26,6 +27,7 @@
     <div class="five wide column folder-navigator-container">
         <div class="ui collapsable grid folder-grid">
             {{ui/files/folder-navigator 
+                model=model
                 currentNavCommand=currentNavCommand
                 openUploadDialog="openUploadDialog"
                 openCreateFolderModal="openCreateFolderModal"

--- a/app/helpers/gt.js
+++ b/app/helpers/gt.js
@@ -1,0 +1,6 @@
+// app/helpers/gt.js
+
+import Ember from 'ember';
+
+const gt = (params) => params[0] > params[1];
+export default Ember.Helper.helper(gt);

--- a/app/helpers/lt.js
+++ b/app/helpers/lt.js
@@ -1,0 +1,6 @@
+// app/helpers/lt.js
+
+import Ember from 'ember';
+
+const lt = (params) => params[0] < params[1];
+export default Ember.Helper.helper(lt);


### PR DESCRIPTION
### Problem
User can launch a Tale to which they don't have sufficient read or write access. Tale Workspaces UI becomes non-functional in this case, since we can't read the Workspace or upload files/folders to it.

Fixes #391

### Approach
Disallow user from selecting Tale Workspaces without read access, disallow Add button without write access

### How to Test
1. Checkout and run this branch locally
2. Login to the WholeTale Dashboard
3. Launch a Tale that does not allow you read access
4. Navigate to Run > Files
    * You should see that Tale Workspaces has been greyed out, disallowing reads
5. Launch a Tale that allows you to read, but not write
6. Navigate to Run > Files > Tale Workspaces
    * You should see the Tale's Workspace folders/files are listed here
    * You should see that (+) has been greyed out, disallowing writes