### PR TITLE
Hide 'Input Data' section on Compose view. Fixes #407

### DIFF
--- a/app/templates/forms/new-tale-input.hbs
+++ b/app/templates/forms/new-tale-input.hbs
@@ -24,7 +24,6 @@
             </div>
         {{/if}}
     </div>
-    {{!--
     <div class="row panel container">
         <div class="five wide column field">
             <label>Input data:</label>
@@ -35,9 +34,8 @@
                     {{item.name}}
                 </div>
             {{else}}
-                <label class="muted-text">Select from Data panel</label>
+                {{!-- <label class="muted-text">Select from Data panel</label> --}}
             {{/each}}
         </div>
     </div>
-    --}}
 </div>

--- a/app/templates/forms/new-tale-input.hbs
+++ b/app/templates/forms/new-tale-input.hbs
@@ -24,6 +24,7 @@
             </div>
         {{/if}}
     </div>
+    {{!--
     <div class="row panel container">
         <div class="five wide column field">
             <label>Input data:</label>
@@ -38,4 +39,5 @@
             {{/each}}
         </div>
     </div>
+    --}}
 </div>


### PR DESCRIPTION
### Problem
'Input Data' portion of Compose view is no longer functional

### Approach
Comment it out for now, until we can add back this functionality

### How to Test
1. Checkout and run this branch locally
2. Login and navigate to Compose
    * You should no longer see "Input Data" or "Select from Data Panel" on the form