### PR TITLE
Firefox should now scroll large lists within the Manage view

### DIFF
--- a/app/components/dashboard/manage/left-panel/template.hbs
+++ b/app/components/dashboard/manage/left-panel/template.hbs
@@ -21,7 +21,7 @@
         </div>
     </div>
 
-    <div class="ui grid">
+    <div class="ui grid" style="overflow: auto;">
         <div class="five wide column folder-navigator-container">
             <div class="ui collapsable grid folder-grid">
               {{ui/files/folder-navigator 


### PR DESCRIPTION
### Problem
Firefox does not seem to respect the `height: -moz-available` style attribute for some reason.

I think this could indicate a problem with how we are nesting/layering Semantic UI components together - I would expect their grid class to allow scrolling unless something other inherited style is interfering.

Fixes #403

### Approach
Since this view is going away in the near future, this is a simple fix for now - add an overflow to the entire grid.

NOTE: This scrolling behavior affects both the `folder-navigator` on the left and the `directory-browser` on the right.

### How to Test
1. Checkout and run this branch locally (is it possible to point your dev instance at girder.stage.wholetale.org?)
2. Open Firefox browser
3. Login and navigate to Manage > Data
4. Register multiple Datasets or files (you can pick random "Raw" file URLs off of GitHub or elsewhere)
    * Once you register enough datasets to push the bottom of the list off of your screen, you should see a scroll bar appear on the right
5. Retest with Chrome to confirm no new side effects
    * NOTE: Chrome only seems to gain one (potentially) odd side effect from this: when the screen height is smaller than `window.outerHeight=559` / `window.innerHeight=206` (approximately the heights of the navbar + paddleboard header + folder navs + footer) you'll see two different scroll bars side-by-side.