### PR TITLE
Turn off backgroundReload when deleting a Tale in the legacy Tale View page

### DIFF
--- a/app/controllers/tale/view.js
+++ b/app/controllers/tale/view.js
@@ -260,11 +260,15 @@ export default Controller.extend({
     approveDelete(model) {
       let component = this;
 
-      model.destroyRecord({
-        reload: true
-      }).then(function () {
-        component.transitionToRoute('browse');
+      let taleId = model.get('_id');
+      this.get('store').findRecord('tale', taleId, { backgroundReload: false }).then(function(tale) {
+        tale.destroyRecord({
+          reload: false
+        }).then(function () {
+          component.transitionToRoute('browse');
+        });
       });
+      
 
       return false;
     },

--- a/app/routes/browse.js
+++ b/app/routes/browse.js
@@ -14,7 +14,8 @@ export default AuthenticateRoute.extend({
         }
       }),
       tales: this.get('store').findAll('tale', {
-        reload: true,
+        reload: false,
+        backgroundReload: false,
         adapterOptions: {
           queryParams: {
             sort: "created",

--- a/app/routes/tale/index.js
+++ b/app/routes/tale/index.js
@@ -4,7 +4,8 @@ export default AuthenticateRoute.extend({
   model() {
     return {
       tales: this.get('store').findAll('tale', {
-        reload: true,
+        backgroundReload: false,
+        reload: false,
         adapterOptions: {
           queryParams: {
             sort: "created",


### PR DESCRIPTION
### Problem
When deleting a Tale from the legacy "Tale View" page, a stack trace occurs preventing the user from being redirected properly to the "Browse" page. This occurs because EmberJS is attempting to automatically fetch a record while it is being deleted or shortly thereafter.

Fixes #395

### Approach
When fetching records, EmberJS has a behavior that will automatically cache them for later updates. You can pass an optional parameter to disable this behavior, which is encouraged when deleting a model.

> The backgroundReload option is used to prevent the fetching of the destroyed record, since findRecord() automatically schedules a fetch of the record from the adapter.

Since I was unsure where the current model being passed in was actually being fetched, or what other views might be reusing the same model, the least intrusive fix seemed to be to add an additional fetch here that explicitly specifies `backgroundReload: false`.

See https://guides.emberjs.com/release/models/creating-updating-and-deleting-records/#toc_deleting-records

### How to Test
1. Checkout and run this branch locally
2. Login to the Dashboard
3. Compose a Tale, if you haven't already
4. Stop/delete the Tale's Instance, if you haven't already
5. Visit the "Tale View" page for this Tale
6. At the top-right, click "Delete Tale"
    * You should be prompted for confirmation
7. Confirm the deletion
    * You should be redirected to the "Browse" page
    * Your deleted Tale should no longer appear in the list here
    * You shouldn't see a big angry stack trace in the logs