### PR TITLE
Remove leading slash from external data

### DIFF
--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -271,15 +271,14 @@ export default Component.extend({
                     'resources': payload
                 });
             } else if (nav.command === "user_data") {
-
               let taleId = this.get('model.taleId'); // state.currentInstanceId;
-                let taleDatasetContents = controller.get('store').findRecord('tale', taleId)
-                    .then(tale => {
-                        return tale.get('dataSet').map(dataset => {
-                            let { itemId, mountPath, _modelType } = dataset;
-                            return { id: itemId, name: mountPath, _modelType };
-                        })
-                    });
+              let taleDatasetContents = controller.get('store').findRecord('tale', taleId, { reload: false })
+                .then(tale => {
+                    return tale.get('dataSet').map(dataset => {
+                        let { itemId, mountPath, _modelType } = dataset;
+                        return { id: itemId, name: mountPath, _modelType };
+                    })
+                });
               itemContents = Promise.resolve(A([]));
               folderContents = taleDatasetContents.then(_taleDatasetContents => {
                 newModel.sessionContents = _taleDatasetContents;
@@ -471,7 +470,7 @@ export default Component.extend({
             // Build up our dataSet list
             let dataSet = listOfSelectedItems.map(item => {
                 let {id, name, _modelType} = item;
-                return {itemId: id, mountPath: name, _modelType};
+                return {itemId: id, mountPath: name.replace(/\//g, ''), _modelType};
             });
             this.session.set('dataSet', dataSet);
           

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -51,7 +51,9 @@ export default Component.extend({
     allSelectedItems: computed('model.tale', function(dataSet) {
       return A(this.get('model.tale').get('dataSet').map(item => {
         let {itemId, mountPath, _modelType} = item;
-        return O({id: itemId, name: mountPath.replace(/\//g, ''), _modelType});
+        // Remove leading slash, if present
+        let name = mountPath[0] === '/' ? mountPath.substring(1) : mountPath;
+        return O({id: itemId, name: name, _modelType});
       }));
     }),
 
@@ -276,7 +278,9 @@ export default Component.extend({
                 .then(tale => {
                     return tale.get('dataSet').map(dataset => {
                         let { itemId, mountPath, _modelType } = dataset;
-                        return { id: itemId, name: mountPath, _modelType };
+                        // Remove leading slash, if present
+                        let name = mountPath[0] === '/' ? mountPath.substring(1) : mountPath;
+                        return { id: itemId, name: name, _modelType };
                     })
                 });
               itemContents = Promise.resolve(A([]));
@@ -470,7 +474,9 @@ export default Component.extend({
             // Build up our dataSet list
             let dataSet = listOfSelectedItems.map(item => {
                 let {id, name, _modelType} = item;
-                return {itemId: id, mountPath: name.replace(/\//g, ''), _modelType};
+                // Remove leading slash, if present
+                let mountPath = name[0] === '/' ? name.substring(1) : name;
+                return {itemId: id, mountPath, _modelType};
             });
             this.session.set('dataSet', dataSet);
           
@@ -522,7 +528,7 @@ export default Component.extend({
             if (listOfSelectedItems) {
                 let resources = { item: [], folder: [] };
                 listOfSelectedItems.forEach(f => {
-                    resources[`${f._modelType}`].push(f.id);
+                    resources[f._modelType].push(f.id);
                 });
                 let payload = JSON.stringify(resources);
                 const currentWorkspaceFolderId = this.get('currentWorkspaceFolderId');

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -278,13 +278,9 @@ export default Component.extend({
                 .then(tale => {
                     return tale.get('dataSet').map(dataset => {
                         let { itemId, mountPath, _modelType } = dataset;
-<<<<<<< HEAD
                         // Remove leading slash, if present
                         let name = mountPath[0] === '/' ? mountPath.substring(1) : mountPath;
                         return { id: itemId, name: name, _modelType };
-=======
-                        return { id: itemId, name: mountPath.replace(/\//g, ''), _modelType };
->>>>>>> 4dcd6595bc2aa72084559dfe9d840fcd34f5f0d9
                     })
                 });
               itemContents = Promise.resolve(A([]));
@@ -478,13 +474,9 @@ export default Component.extend({
             // Build up our dataSet list
             let dataSet = listOfSelectedItems.map(item => {
                 let {id, name, _modelType} = item;
-<<<<<<< HEAD
                 // Remove leading slash, if present
                 let mountPath = name[0] === '/' ? name.substring(1) : name;
                 return {itemId: id, mountPath, _modelType};
-=======
-                return {itemId: id, mountPath: name, _modelType};
->>>>>>> 4dcd6595bc2aa72084559dfe9d840fcd34f5f0d9
             });
             this.session.set('dataSet', dataSet);
           


### PR DESCRIPTION
### Problem
Sometimes External Data displays datasets prepended with a leading slash.

Fixes #411 

### Approach
Replace `/` with an empty string when building up the `mountPath`, as we do with other places in that view (such as `allSelectedItems` in the `select-data-modal`).

NOTE: I am just following the established pattern here, but I wonder if the `g` at the end of the replace regex could cause problems with dataSets that should actually contain such slashes? For example: https://search.dataone.org/view/doi:10.5063/F1C827JF, whose title contains a URL/DOI, display as `Data supporting meta‐analysis of multiple ecosystem outcomes from organic amendment additions to rangelands (https:doi.org10.1111gcb.14535)` - this is obviously not ideal

### How to Test
1. Checkout and run this branch locally, rebuild dashboard
2. Register a dataset known to display this problematic behavior (e.g. LIGO Tale)
3. Login and launch a Tale, if you haven't already
4. Navigate to Run > Files > External Data
5. Open the "Select Data", add the dataset to the Tale, and click "Select"
    * You should see the modal dismiss itself
    * You should see the dataset appear in the External Data list
    * You should see that the dataset name is no longer lead by slashes
  