### PR TITLE
Return the home folder if the currentFolderID is empty/undefined

### DIFF
--- a/app/services/folder-navs.js
+++ b/app/services/folder-navs.js
@@ -6,7 +6,8 @@ import {
 export default Service.extend({
     userAuth: service(),
     internalState: service(),
-
+    store: service(),
+    
     getFolderNavs() {
         const thisUserID = this.get('userAuth').getCurrentUserID();
 
@@ -83,6 +84,23 @@ export default Service.extend({
         obj.set("currentNavTitle", currentNav.name);
         obj.set("currentNav", currentNav);
         return currentNav;
-    }
-
-});
+    },
+    getHomeFolder() {
+      let nav = this.getFolderNavFor('home');
+      this.store.query('folder', {
+        parentId: nav.parentId,
+        parentType: nav.parentType,
+        name: nav.name,
+        reload: true,
+        adapterOptions: {
+          queryParams: {
+            limit: "0"
+          }
+        }
+      }).then(folders => {
+        if (folders.length) {
+          let folder_id = folders.content[0].id;
+          return folder_id;}
+        });
+      }
+    });

--- a/app/services/internal-state.js
+++ b/app/services/internal-state.js
@@ -9,7 +9,6 @@ import { A } from '@ember/array';
 export default Service.extend({
     isAuthenticated: true,
     store: service(),
-    userAuth: service('user-auth'),
     folderNavs: service(),
     currentInstanceId: computed({
         get() {

--- a/app/services/internal-state.js
+++ b/app/services/internal-state.js
@@ -9,6 +9,8 @@ import { A } from '@ember/array';
 export default Service.extend({
     isAuthenticated: true,
     store: service(),
+    userAuth: service('user-auth'),
+    folderNavs: service(),
     currentInstanceId: computed({
         get() {
             return (localStorage.currentInstanceId && localStorage.currentInstanceId !== 'undefined') ? JSON.parse(localStorage.currentInstanceId) : undefined;
@@ -32,23 +34,25 @@ export default Service.extend({
     },
 
     getCurrentFolderID() {
-        let currentFolderID = localStorage.currentFolderID;
+      // Gets the current selected folder. If an error occurs, return the home
+      // directory
+      let currentFolderID = localStorage.currentFolderID;
+      let self=this;
 
-        // Skip checking falsey ID strings
-        if (typeof(currentFolderID) !== "undefined" && currentFolderID) {
-            this.store.findRecord('folder', currentFolderID).then(function(result) {
-                // folder exists - effectively a noop
-                // NOTE: after first lookup, this result is cached in the store
-            }).catch(function(error) {
-                // Set currentFolderID to "undefined" and refresh the page
-                localStorage.removeItem("currentFolderID");
-                currentFolderID = undefined;
-                window.location.reload(true);
-            });
-        }
-
+      // Skip checking falsey ID strings
+      if (typeof(currentFolderID) !== "undefined" && currentFolderID) {
+        self.store.findRecord('folder', currentFolderID).then(function(result) {
+          // folder exists - effectively a noop
+          // NOTE: after first lookup, this result is cached in the store
+        }).catch(function(error) {
+          return self.folderNavs.getHomeFolder();
+        });
         return currentFolderID;
-    },
+      }
+      else {
+        return self.folderNavs.getHomeFolder();
+      }
+  },
 
     setCurrentFolderName(val) {
         localStorage.currentFolderName = val;


### PR DESCRIPTION
I added a method to the folder-navs to return the ID of the home folder which is used in the internal-state service. 

If the `currentFolderID` is undefined, then return the ID of the home folder. This should fix issue #381.

To Test:
1. Clone & Deploy locally
2. Delete the `currentFolderID` local storage object
3. Browse WT
4. Repeat 2-3

The important pages to view are the compose and run pages.
