### PR TITLE
Hide buttons that either won't work or won't give user notification on failure

### DIFF
--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -86,11 +86,11 @@
                                 <i class="dropdown icon"></i>
                                 <div class="menu">
                                     {{#if (and (eq currentNav.command 'workspace') (lt model.tale._accessLevel 1))}}
-                                        <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                        {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
                                         <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
                                                 class="download icon"></i> Download</a>
                                     {{else}}
-                                        <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
+                                        {{!-- <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a> --}}
                                         {{#if (eq currentNav.command 'user_data')}}
                                             <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
                                                     class="download icon"></i> Download</a>
@@ -99,7 +99,7 @@
                                                 Rename...</a>
                                             {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a>--}}
                                             {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
-                                                <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                                {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
                                             {{else}}
                                                 <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
                                                 <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
@@ -140,19 +140,19 @@
                                 <i class="dropdown icon"></i>
                                 <div class="menu">
                                     {{#if (and (eq currentNav.command 'workspace') (lt model.tale._accessLevel 1))}}
-                                        <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                        {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
                                         <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
                                                 class="download icon"></i> Download</a>
                                     {{else if (eq currentNav.command 'user_data')}}
                                         <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
                                                 class="download icon"></i> Download</a>
                                     {{else}}
-                                        <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
+                                        {{!-- <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a> --}}
                                         <a class="item" {{action "rename" item}}><i class="write square icon"></i>
                                             Rename...</a>
                                         {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a> --}}
                                         {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
-                                            <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
+                                            {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
                                         {{else}}
                                             <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
                                         {{/if}}

--- a/app/components/ui/tale-browser/template.hbs
+++ b/app/components/ui/tale-browser/template.hbs
@@ -212,7 +212,7 @@
                                                             {{#if showSelect}}
                                                                 <div class="ui inverted button" {{action 'select' model}}>Select</div>
                                                             {{/if}}
-                                                            {{#if showDelete}}
+                                                            {{#if (and showDelete (gt model._accessLevel 0))}}
                                                                 <a class="ui tiny bottom right attached label" {{action 'attemptDeletion' model}}>
                                                                     <i class="red remove icon"></i>
                                                                 </a>
@@ -308,7 +308,7 @@
                                         {{#if showSelect}}
                                             <div class="ui inverted button" {{action 'select' model}}>Select</div>
                                         {{/if}}
-                                        {{#if showDelete}}
+                                        {{#if (and showDelete (gt model._accessLevel 0))}}
                                             <a class="ui tiny bottom right attached label" {{action 'attemptDeletion' model}}>
                                                 <i class="red remove icon"></i>
                                             </a>


### PR DESCRIPTION
### Problem
These functions currently have outstanding problems that will not be fixed for this release.

Fixes #409
Fixes #415 

### Approach
We should hide them from the Tale Workspaces UI for now, until they can be investigated and fixed.

### How to Test
1. Checkout and run this branch locally
2. Login to the WholeTale Dashboard
3. Navigate to "Browse" and hover over a Tale to which you do not have access
    * You should not see the X button on Tale's to which you do not have write access (#409)
4. Switch to Cards view and hover over the image (first column) of a Tale to which you do not have access
    * You should not see the X button on Tale's to which you do not have write access (#409)
5. Launch a Tale to which you have access (if you haven't already)
6. Navigate to Run > Files > Tale Workspaces
7. Create a folder or file (if you haven't already)
8. Expand the dropdown next to the folder or file
    * You should **not** see options for "Copy to Home" or "Move To..." listed here (#415)
    * You should see only "Rename" and "Download" in the read-write case
    * You should see only "Download" in the read-only case