### PR TITLE
Disable Run > Files > External Data UI if insufficient Tale access

### DIFF
--- a/app/components/ui/files/bread-crumbs/template.hbs
+++ b/app/components/ui/files/bread-crumbs/template.hbs
@@ -2,7 +2,7 @@
     <div class="ui large breadcrumb">
         <a class="section {{if justDescription 'bold'}}" {{action "navClicked" currentNav}}> {{#if justDescription}} {{currentNav.displayName}} {{else}} {{currentNav.name}} {{/if}}</a>
         {{#if justDescription}}
-            {{#if (and (lt model.tale._accessLevel 1) (eq currentNav.command 'workspace'))}}
+            {{#if (and (lt model.tale._accessLevel 1) (or (eq currentNav.command 'workspace') (eq currentNav.command 'user_data')))}}
                 <i class="fas fa-plus-circle icon blue large disabled" disabled style="cursor:not-allowed !important;"></i>
             {{else}}
                 <i class="fas fa-plus-circle icon blue large" onclick={{action 'triggerBreadcrumbAction' currentNav.name}}></i>

--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -40,9 +40,11 @@
                                 <a class="item" href="{{apiUrl}}/{{item._modelType}}/{{item.id}}/download?contentDisposition=attachment">
                                     <i class="download icon"></i> Download
                                 </a>
+                                {{#if (gt model.tale._accessLevel 0)}}
                                 <a class="item" href="#" {{action "removeDataset" item.id}}>
                                     <i class="trash icon"></i> Remove
                                 </a>
+                                {{/if}}
                             </div>
                         {{/ui-dropdown}}
                     </td>

--- a/app/components/ui/files/folder-navigator/template.hbs
+++ b/app/components/ui/files/folder-navigator/template.hbs
@@ -113,26 +113,24 @@
                                     {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}} {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
                                 </div>
                             </a>
+                        {{else if (and (and (lt model.tale._accessLevel 1) (eq model.tale.public 'false')) (or (eq nav.command "workspace") (eq nav.command "user_data")))}}
+                            <a class="item disabled" disabled {{action "navClicked" nav}} data-tooltip="You do not have read access to this Tale's Workspace." data-inverted="">
+                                <div style="padding-left: 1rem; padding-top: 4px;">
+                                    <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
+                                </div>
+                                <div class="icon-wrapper">
+                                    {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}} {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
+                                </div>
+                            </a>    
                         {{else}}
-                            {{#if (and (and (lt model.tale._accessLevel 1) (eq model.tale.public 'false')) (eq nav.command "workspace"))}}
-                                <a class="item disabled" disabled {{action "navClicked" nav}} data-tooltip="You do not have read access to this Tale's Workspace." data-inverted="">
-                                    <div style="padding-left: 1rem; padding-top: 4px;">
-                                        <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
-                                    </div>
-                                    <div class="icon-wrapper">
-                                        {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}} {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
-                                    </div>
-                                </a>    
-                            {{else}}
-                                <a class="item" {{action "navClicked" nav}}>
-                                    <div style="padding-left: 1rem; padding-top: 4px;">
-                                        <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
-                                    </div>
-                                    <div class="icon-wrapper">
-                                        {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}} {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
-                                    </div>
-                                </a>
-                            {{/if}}
+                            <a class="item" {{action "navClicked" nav}}>
+                                <div style="padding-left: 1rem; padding-top: 4px;">
+                                    <span class="instructions">{{#if useIcons}}{{nav.instructions}}{{else}}{{nav.description}}{{/if}}</span>
+                                </div>
+                                <div class="icon-wrapper">
+                                    {{#if useIcons}}<i class="{{nav.icon}} icon big"></i>{{/if}} {{#if useIcons}} {{nav.name}} {{else}} {{nav.displayName}} {{/if}} <span class="chevron-span"><i class="fas fa-2x fa-chevron-right"></i></span>
+                                </div>
+                            </a>
                         {{/if}}
                     </div>
                 {{/unless}}


### PR DESCRIPTION
### Problem
User can launch a Tale to which they don't have sufficient read or write access. External Data UI becomes non-functional in this case, since we can't read the Tale or attach datasets to it.

Fixes #417

### Approach
Disallow user from selecting External Data without read access, disallow Add button without write access

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch a Tale that does not allow you read access
4. Navigate to Run > Files
    * You should see that External Data has been greyed out, disallowing reads
5. Launch a Tale that allows you to read, but not write
6. Navigate to Run > Files > External Data
    * You should see the Tale's associated datasets are listed here
    * You should see that (+) has been greyed out, disallowing writes