### PR TITLE
Add overflow style attribute (same fix as in the Manage view)

### DIFF
--- a/app/components/ui/tale-tab-files/template.hbs
+++ b/app/components/ui/tale-tab-files/template.hbs
@@ -23,7 +23,7 @@
         </div>
     </div>
 </div>
-<div class="ui grid">
+<div class="ui grid" style="overflow: auto;">
     <div class="five wide column folder-navigator-container">
         <div class="ui collapsable grid folder-grid">
             {{ui/files/folder-navigator 


### PR DESCRIPTION
### Problem
In Chrome, we found today that the Run > Files > Tale Workspaces view does not render properly when the list is very long.

### Approach
As with #410, a simple fix for now is to add an `overflow:auto` on the surrounding `class="ui grid"`. 

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch a Tale
4. Navigate to Run > Files > Tale Workspaces
5. Create enough folders/items to push the bottom of the list off the screen
    * A scroll bar should appear, allowing you to scroll down in the table as normal
    * The footer should stay stuck to the bottom of the viewport
    * The footer should **not** overlap with any of the folders/items in the list


#### Aside: The Long-Term Fix
The long-term fix would be to investigate our component layering to make sure we don't have conflicting or nonsensical CSS values being cascaded to child elements.

For example: this view contains one or more nested grids with custom classes (e.g `collapsable`) whose format do not match that of the samples here: https://semantic-ui.com/collections/grid.html#nesting-grids

Custom styling applied:
```sass
      .directory-browser-container {
            .ui.collapsable.grid {
                height: 100%;
                .directory-browser {
                    height: 100%;
                    margin-right: 3px;
                    .left.panel.content {
                        height: 100%;
                        table {
                            height: auto;
                            max-height: 100%;
                            width: calc(100% - 10px);
                            margin: 0 10px;
                            tbody {
                                max-height: calc(100% - 45px);
                                overflow-y: auto;
                            }
                        }
                    }
                }
            }
        }
```
