### PR TITLE
Fixed sort order for Compute Environments

### DIFF
--- a/app/routes/compose/index.js
+++ b/app/routes/compose/index.js
@@ -53,7 +53,7 @@ export default AuthenticateRoute.extend({
         reload: true,
         adapterOptions: {
           queryParams: {
-            sort: "lowerName",
+            sort: "created",
             sortdir: "1",
             limit: "50"
           }


### PR DESCRIPTION
### Problem
The default "sort order" for compute environments was set to `lowerName`. Since `image` models don't have a field called `lowerName`, I am surprised that the API did not complain or throw a 400.

NOTE: `lowerName` is also the default for the endpoint, defined here: https://girder.local.wholetale.org/api/v1#!/image/image_listImages

### Approach
Sort, instead, by the image's `created` date.

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Compose
    * You should see that the compute environments are now sorted by creation date
    * Compare with https://girder.local.wholetale.org/api/v1#!/image/image_listImages
        * Don't forget to set `sort=created` and `sortdir=1` to match the inputs sent by the UI