### PR TITLE
Bring back 'Move To...' for Home folder

### DIFF
--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -85,29 +85,27 @@
                                 </a>
                                 <i class="dropdown icon"></i>
                                 <div class="menu">
-                                    {{#if (and (eq currentNav.command 'workspace') (lt model.tale._accessLevel 1))}}
-                                        {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
-                                        <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
-                                                class="download icon"></i> Download</a>
-                                    {{else}}
-                                        {{!-- <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a> --}}
-                                        {{#if (eq currentNav.command 'user_data')}}
-                                            <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
-                                                    class="download icon"></i> Download</a>
+                                    {{!-- Only show if Home folder --}}
+                                    {{#if (eq currentNav.command 'home')}}
+                                        <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
+                                    {{/if}}
+                                    
+                                    {{!-- Only show if Home folder, or if Workspace with write access --}}
+                                    {{#if (or (and (eq currentNav.command 'workspace') (gt model.tale._accessLevel 0)) (eq currentNav.command 'home'))}}
+                                        <a class="item" {{action "rename" item}}><i class="write square icon"></i>
+                                            Rename...</a>
+                                        {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a>--}}
+                                        {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
+                                            {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
                                         {{else}}
-                                            <a class="item" {{action "rename" item}}><i class="write square icon"></i>
-                                                Rename...</a>
-                                            {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a>--}}
-                                            {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
-                                                {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
-                                            {{else}}
-                                                <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
-                                                <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
-                                            {{/if}}
-                                            <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
-                                                    class="download icon"></i> Download</a>
+                                            <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
+                                            <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                         {{/if}}
                                     {{/if}}
+                                    
+                                    {{!-- Always show Download option --}}
+                                    <a class="item" href="{{apiUrl}}/folder/{{item.id}}/download?contentDisposition=attachment"><i
+                                            class="download icon"></i> Download</a>
                                 </div>
                             {{/ui-dropdown}}
                         {{/if}}
@@ -139,15 +137,10 @@
                                 </a>
                                 <i class="dropdown icon"></i>
                                 <div class="menu">
-                                    {{#if (and (eq currentNav.command 'workspace') (lt model.tale._accessLevel 1))}}
-                                        {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
-                                        <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
-                                                class="download icon"></i> Download</a>
-                                    {{else if (eq currentNav.command 'user_data')}}
-                                        <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
-                                                class="download icon"></i> Download</a>
-                                    {{else}}
-                                        {{!-- <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a> --}}
+                                    {{#if (eq currentNav.command 'home')}}
+                                        <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
+                                    {{/if}}
+                                    {{#if (or (and (eq currentNav.command 'workspace') (gt model.tale._accessLevel 0)) (eq currentNav.command 'home'))}}
                                         <a class="item" {{action "rename" item}}><i class="write square icon"></i>
                                             Rename...</a>
                                         {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a> --}}
@@ -156,10 +149,10 @@
                                         {{else}}
                                             <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
                                         {{/if}}
-                                        <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
-                                                class="download icon"></i> Download</a>
                                         <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                     {{/if}}
+                                    <a class="item" href="{{apiUrl}}/item/{{item.id}}/download?contentDisposition=attachment"><i
+                                            class="download icon"></i> Download</a>
                                 </div>
                             {{/ui-dropdown}}
                         {{/if}}


### PR DESCRIPTION
### Problem
PR #416 hid some functionality that actually still operates as expected:
* The user should still be able to Move files from one subfolder to another within their home folder
* The UI is unable to support moving items between Workspace folders in this way, but this can still be accomplished via the `tale-workspaces-modal`
* The user should NOT be able to move items between the Workspace and Home folder via the UI at this time

### Approach
Bring back 'Move To...' when in Home context and refactor the `directory-browser` template logic to be a bit more sane.

We should also be thinking about how to consolidate the above workflows going forward - do we want to keep the "Move To..." modal? Perhaps this could/should be built into the Tale Workspaces modal? Food for thought.

### How to Test
Preconditions: at least one Tale without write access and at least one workspace folder created in that Tale's Workspace

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch a Tale to which you only have read access
4. Navigate to Run > Files > Home
5. Create a folder or upload an item, if you haven't already
6. Click the dropdown arrow to the right of the folder or item
    * You should be offered options to "Move To...", "Rename", "Copy", "Remove", or "Download"
7. Navigate to Run > Files > Tale Workspaces
8. Click the dropdown arrow to the right of the folder or item (assumes owner has added a folder/file)
    * You should only be offered an option to "Download"
9. Now, launch a Tale to which you have write access
10. Navigate to Run > Files > Home
11. Click the dropdown arrow to the right of the folder or item
    * You should be offered the same options as above: "Move To...", "Rename", "Copy", "Remove", or "Download"
12. Navigate to Run > Files > Tale Workspaces
13. Create a folder or upload an item, if you haven't already
14. Click the dropdown arrow to the right of the folder or item
    * You should be offered options to either "Rename" or "Download"
15. Navigate to the Manage view
16. Select the Home nav
17. Click the dropdown arrow to the right of the folder or item
    * You should be offered the same options as above: "Move To...", "Rename", "Copy", "Remove", or "Download"
18. Select the Data nav
19. Register a dataset (if you haven't already)
20. Click the dropdown arrow to the right of the dataset
    * You should only be offered options to either "Remove" or "Download"

NOTE: Run > Files > External Data is unaffected here, because it does not use the `directory-browser`