### PR TITLE
Handle 'undefined' string literal in internal-state null-checking

### DIFF
--- a/app/components/dashboard/manage/left-panel/component.js
+++ b/app/components/dashboard/manage/left-panel/component.js
@@ -92,12 +92,23 @@ export default Component.extend({
 
     this.set('fileBreadCrumbs', state.getCurrentFileBreadcrumbs()); // new collection, reset crumbs
   },
+  resync() {
+      let nav = this.get('currentNav');
+      this.send('navClicked', nav);
+  },
 
   actions: {
     refresh(adapterOptions = { queryParams: { limit: '0' } }) {
       let state = this.get('internalState');
       let myController = this;
       let itemID = state.getCurrentFolderID();
+      
+      // Short-circuit: Datasets are no longer read from these endpoints
+      let nav = this.get('currentNav');
+      if (nav.command == 'user_data') {
+        myController.resync();
+        return;
+      }
 
       let folderContents = myController.store.query('folder', {
         parentId: itemID,

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -126,6 +126,13 @@ export default Component.extend({
             let state = this.get('internalState');
             let myController = this;
             let itemID = state.getCurrentFolderID();
+      
+            // Short-circuit: Datasets are no longer read from these endpoints
+            let nav = this.get('currentNav');
+            if (nav.command == 'user_data') {
+                myController.resync();
+                return;
+            }
 
             let folderContents = myController.store.query('folder', {
                 parentId: itemID,

--- a/app/services/internal-state.js
+++ b/app/services/internal-state.js
@@ -39,7 +39,7 @@ export default Service.extend({
       let self=this;
 
       // Skip checking falsey ID strings
-      if (typeof(currentFolderID) !== "undefined" && currentFolderID) {
+      if (typeof(currentFolderID) !== "undefined" && currentFolderID !== "undefined" && currentFolderID) {
         self.store.findRecord('folder', currentFolderID).then(function(result) {
           // folder exists - effectively a noop
           // NOTE: after first lookup, this result is cached in the store


### PR DESCRIPTION
### Problem
While our `internal-state` service does handle `undefined` values properly, it does not handle the `"undefined"` string literal.

Fixes #422

### Approach
While the thorough/correct fix would likely be to make sure we aren't assigning the `"undefined"` string literal anywhere (as this is a meaningless arbitrary string), to get things moving in the short-term we can simply handle this as a special value.

Note that this anti-pattern only currently doesn't present many problems because the field represents a specially-formatted ID - the same pattern for null-checking could not be applied to other fields, such as `currentFolderName`, since `"undefined"` is actually a valid name for a user to give to a folder

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Manage > Data
4. Register a dataset, if you haven't already
    * Your view should automatically update or refresh to display the new dataset
5. Delete the dataset you just registered
    * Your view should automatically update to show that the dataset has been disassociated from your user
6. Navigate to Run
7. Navigate back to Manage
    * You should be able to navigate successfully

Compare with https://dashboard.stage.wholetale.org/manage for reference