### PR TITLE
Improved breadcrumbs on Run > Files and Manage views to show full path. Fixes #425

### DIFF
--- a/app/components/dashboard/manage/left-panel/component.js
+++ b/app/components/dashboard/manage/left-panel/component.js
@@ -1,8 +1,9 @@
 import TextField from '@ember/component/text-field';
+import { A } from '@ember/array';
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { observer, computed } from '@ember/object';
-import Object from '@ember/object';
+import EmberObject from '@ember/object';
 import $ from 'jquery';
 
 function wrapFolder(folderID, folderName) {
@@ -328,15 +329,14 @@ export default Component.extend({
     },
 
     breadcrumbClicked(item) {
-      let state = this.get('internalState');
-      let crumbs = state.getCurrentFileBreadcrumbs();
-      let self = this;
-      let adapterOptions = { queryParams: { limit: "0" } };
+      const state = this.get('internalState');
+      const crumbs = state.getCurrentFileBreadcrumbs();
+      const self = this;
+      const adapterOptions = { queryParams: { limit: "0" } };
 
-      let previousItem = null;
-      let newCrumbs = [];
-      for (let i; i < crumbs.length; ++i) {
-        if (crumbs[i].name === item.get('name')) {
+      const newCrumbs = A([]);
+      for (let i = 0; i < crumbs.length; ++i) {
+        if (crumbs[i].name === item.name) {
           if (i == 0 && this.get('currentNav') == 'user_data') {
             self.set('fileData', { itemContents: [], folderContents: [] });
             self.get('store').query('dataset', { myData: true, adapterOptions }).then(datasets => {
@@ -345,19 +345,18 @@ export default Component.extend({
           }
           break;
         } else {
-          newCrumbs.append(crumbs[i]);
-          previousItem = crumbs[i];
+          newCrumbs.pushObject(crumbs[i]);
         }
       }
 
       state.setCurrentFileBreadcrumbs(newCrumbs);
       state.setCurrentFolderID(item._id);
       state.setCurrentFolderName(item.name);
-      state.setCurrentBreadCrumb(previousItem); // need to set this because itemClicked is expecting the previous breadcrumb.
+      state.setCurrentBreadCrumb(null);  // no need to set this here, we already have our full breadcrumbs
 
       this.set('currentFolderId', item._id);
 
-      this.send('itemClicked', Object.create(item), 'true');
+      this.send('itemClicked', EmberObject.create(item), 'true');
     },
 
     //----------------------------------------------------------------------------

--- a/app/components/ui/files/bread-crumbs/template.hbs
+++ b/app/components/ui/files/bread-crumbs/template.hbs
@@ -1,39 +1,48 @@
 {{#if isMain}}
-    <div class="ui large breadcrumb">
-        <a class="section {{if justDescription 'bold'}}" {{action "navClicked" currentNav}}> {{#if justDescription}} {{currentNav.displayName}} {{else}} {{currentNav.name}} {{/if}}</a>
-        {{#if justDescription}}
-            {{#if (and (lt model.tale._accessLevel 1) (or (eq currentNav.command 'workspace') (eq currentNav.command 'user_data')))}}
-                <i class="fas fa-plus-circle icon blue large disabled" disabled style="cursor:not-allowed !important;"></i>
-            {{else}}
-                <i class="fas fa-plus-circle icon blue large" onclick={{action 'triggerBreadcrumbAction' currentNav.name}}></i>
-            {{/if}}
-            {{#if displayFoldersMenu}}
-                {{#click-outside action=(action (mut displayFoldersMenu) false)}}
-                    <div class="folder-menu">
-                        <div class="ui vertical left menu transition">
-                            <div class="header">{{currentNav.name}} Options</div>
-                            <a class="item" onclick={{action 'openCreateFolderModal'}}>
-                                New Folder <div class="ui label transparent"><i class="fas fa-folder"></i></div>
-                            </a>
-                            <a class="item" onclick={{action 'openUploadDialog'}}>
-                                Upload File <div class="ui label transparent"><i class="fas fa-upload"></i></div>
-                            </a>
-                            {{#if (eq currentNav.command 'workspace')}}
-                                <a class="item" onclick={{action 'openWorkspacesDataModal'}}>
-                                    Import Tale Data...
+    <div class="ui grid">
+        {{!-- Breadcrumb --}}
+        <div class="fifteen wide column">
+            <div class="ui large breadcrumb">
+                <a class="section {{if justDescription 'bold'}}" {{action "navClicked" currentNav}}> {{#if justDescription}} {{currentNav.displayName}} {{else}} {{currentNav.name}} {{/if}}</a>
+                {{#each fileBreadCrumbs as |bc|}}
+                    <i class="right chevron icon divider"></i>
+                    <a class="section" {{action "breadcrumbClicked" bc}}>{{truncate-breadcrumb bc.name}}</a>
+                {{/each}}
+                {{#if currentBreadCrumb.name}}<i class="right chevron icon divider"></i>{{/if}}
+                <div class="active section bold">{{truncate-breadcrumb currentBreadCrumb.name}}</div>
+            </div>
+        </div>
+        
+        {{!-- Add Button --}}
+        <div class="one wide column">
+            {{#if justDescription}}
+                {{#if (and (lt model.tale._accessLevel 1) (or (eq currentNav.command 'workspace') (eq currentNav.command 'user_data')))}}
+                    <i id="add-item-button" class="fas fa-plus-circle icon blue large disabled" disabled style="cursor:not-allowed !important;"></i>
+                {{else}}
+                    <i id="add-item-button" class="fas fa-plus-circle icon blue large" {{action 'triggerBreadcrumbAction' currentNav.name}}></i>
+                {{/if}}
+                {{#if displayFoldersMenu}}
+                    {{#click-outside action=(action (mut displayFoldersMenu) false)}}
+                        <div id="folder-menu" class="folder-menu">
+                            <div class="ui vertical left menu transition">
+                                <div class="header">{{currentNav.name}} Options</div>
+                                <a class="item" onclick={{action 'openCreateFolderModal'}}>
+                                    New Folder <div class="ui label transparent"><i class="fas fa-folder"></i></div>
                                 </a>
-                            {{/if}}
+                                <a class="item" onclick={{action 'openUploadDialog'}}>
+                                    Upload File <div class="ui label transparent"><i class="fas fa-upload"></i></div>
+                                </a>
+                                {{#if (eq currentNav.command 'workspace')}}
+                                    <a class="item" onclick={{action 'openWorkspacesDataModal'}}>
+                                        Import Tale Data...
+                                    </a>
+                                {{/if}}
+                            </div>
                         </div>
-                    </div>
-                {{/click-outside}}
+                    {{/click-outside}}
+                {{/if}}
             {{/if}}
-        {{/if}}
-        {{#each fileBreadCrumbs as |bc|}}
-            <i class="right chevron icon divider"></i>
-            <a class="section" {{action "breadcrumbClicked" bc}}>{{truncate-breadcrumb bc.name}}</a>
-        {{/each}}
-        {{#if currentBreadCrumb.name}}<i class="right chevron icon divider"></i>{{/if}}
-        <div class="active section bold">{{truncate-breadcrumb currentBreadCrumb.name}}</div>
+        </div>
     </div>
 {{else}}
     <div class="ui grid">

--- a/app/components/ui/files/bread-crumbs/template.hbs
+++ b/app/components/ui/files/bread-crumbs/template.hbs
@@ -27,12 +27,11 @@
                     </div>
                 {{/click-outside}}
             {{/if}}
-        {{else}}
-            {{#each fileBreadCrumbs as |bc|}}
-                <i class="right chevron icon divider"></i>
-                <a class="section" {{action "breadcrumbClicked" bc}}>{{truncate-breadcrumb bc.name}}</a>
-            {{/each}}
         {{/if}}
+        {{#each fileBreadCrumbs as |bc|}}
+            <i class="right chevron icon divider"></i>
+            <a class="section" {{action "breadcrumbClicked" bc}}>{{truncate-breadcrumb bc.name}}</a>
+        {{/each}}
         {{#if currentBreadCrumb.name}}<i class="right chevron icon divider"></i>{{/if}}
         <div class="active section bold">{{truncate-breadcrumb currentBreadCrumb.name}}</div>
     </div>
@@ -44,7 +43,7 @@
         <div class="fifteen wide column" style="padding: 0; margin: 0;">
             <div class="ui large breadcrumb">
                 <a class="section"> {{currentNavTitle}}</a>
-
+                
                 {{#each fileBreadCrumbs as |bc|}}
                     <a class="section" {{action "breadcrumbClicked" bc}}>{{truncate-breadcrumb bc.name}}</a>
                     <i class="right chevron icon divider"></i>

--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -376,21 +376,19 @@ export default Component.extend({
             let state = this.get('internalState');
             let crumbs = state.getCurrentFileBreadcrumbs();
 
-            let previousItem = null;
-            let newCrumbs = [];
-            for (let i; i < crumbs.length; ++i) {
-                if (crumbs[i].name === item.get('name'))
+            let newCrumbs = A([]);
+            for (let i = 0; i < crumbs.length; ++i) {
+                if (crumbs[i].name === item.name)
                     break;
                 else {
-                    newCrumbs.append(crumbs[i]);
-                    previousItem = crumbs[i];
+                    newCrumbs.pushObject(crumbs[i]);
                 }
             }
 
             state.setCurrentFileBreadcrumbs(newCrumbs);
             state.setCurrentFolderID(item._id);
             state.setCurrentFolderName(item.name);
-            state.setCurrentBreadCrumb(previousItem); // need to set this because itemClicked is expecting the previous breadcrumb.
+            state.setCurrentBreadCrumb(null);  // no need to set this here, we already have our full breadcrumbs
 
             this.set('currentFolderId', item._id);
 

--- a/app/services/internal-state.js
+++ b/app/services/internal-state.js
@@ -75,7 +75,7 @@ export default Service.extend({
 
     getCurrentFileBreadcrumbs() {
         let bcs = localStorage.currentFileBreadcrumbs;
-        if (!bcs) return null;
+        if (!bcs) return [];
         return JSON.parse(bcs);
     },
 

--- a/app/styles/tale-tab-files.scss
+++ b/app/styles/tale-tab-files.scss
@@ -1,63 +1,61 @@
 @import 'variables';
 
+
+#add-item-button {
+    position: absolute;
+    right: 0;
+    top: 25%;
+    cursor: pointer;
+    display: inline;
+}
+#add-item-button + .ember-view {
+    display: inline;
+}
+
+
+#folder-menu {
+    position: absolute;
+    right: 5px;
+    top: 35px;
+    z-index: 10;
+
+    .vertical.menu {
+        width: 190px;
+        box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
+        border: 1px solid rgba(34, 36, 38, 0.15);
+        border-radius: 0.28571429rem;
+        -webkit-transition: opacity 0.1s ease;
+        transition: opacity 0.1s ease;
+        z-index: 11;
+        will-change: transform, opacity;
+
+        .header {
+            margin: 1rem 0 .75rem;
+            padding: 0 1.14285714rem;
+            color: rgba(0,0,0,.85);
+            font-size: .78571429em;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+        .item::before {
+            height: 0;
+        }
+
+        .item {
+            border: none;
+            .label {
+                background-color: transparent;
+                color: black;
+            }
+        }
+    }
+}
+
 .tale-tab-files {
     height: calc(100vh - (2rem + #{$inverted-menu-height} + #{$footer-height} + 80px + #{$wt-main-row-height}));
 
     .main-row {
         padding: 0.5rem 1.6rem;
-        .files-tab-description {
-            .breadcrumbs-container {
-                .breadcrumb {
-                    .fa-plus-circle {
-                        position: absolute;
-                        right: 0;
-                        bottom: 3px;
-                        cursor: pointer;
-                        display: inline;
-                    }
-                    .fa-plus-circle + .ember-view {
-                        display: inline;
-                    }
-                    .folder-menu {
-                        position: absolute;
-                        right: 5px;
-                        top: 35px;
-                        z-index: 10;
-        
-                        .vertical.menu {
-                            width: 190px;
-                            box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
-                            border: 1px solid rgba(34, 36, 38, 0.15);
-                            border-radius: 0.28571429rem;
-                            -webkit-transition: opacity 0.1s ease;
-                            transition: opacity 0.1s ease;
-                            z-index: 11;
-                            will-change: transform, opacity;
-
-                            .header {
-                                margin: 1rem 0 .75rem;
-                                padding: 0 1.14285714rem;
-                                color: rgba(0,0,0,.85);
-                                font-size: .78571429em;
-                                font-weight: 700;
-                                text-transform: uppercase;
-                            }
-                            .item::before {
-                                height: 0;
-                            }
-        
-                            .item {
-                                border: none;
-                                .label {
-                                    background-color: transparent;
-                                    color: black;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 
     .ui.grid:not(.files-tab-description) {


### PR DESCRIPTION
### Problem
The Run > Files view never apparently does not show the full breadcrumb path. This makes it difficult for user to navigate back up after clicking down into multiple nested folders.

Fixes #425 

### Approach
Always show the full breadcrumbs.

In the future if we dislike this pattern, we can potentially add options to configure the max depth and/or truncate the full path into a popover or something similar.

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch a Tale, if you haven't already
4. Navigate to Run > Files > Home
    * You should see your breadcrumb at the top simply reads `Home`
5. Create a folder called `depth1` and click into it
    * You should see your breadcrumb at the top displays the full path of `Home > depth1`
6. Create a folder called `depth2` and click into it
    * You should see your breadcrumb at the top still displays the full path of `Home > depth1 > depth2`
7. Create a folder called `depth3` and click into it
    * You should see your breadcrumb at the top continues to display the full path of `Home > depth1 > depth2 > depth3`
8. Click back to `depth2`
    * You should see that `depth3` is dropped, leaving you with `Home > depth1 > depth2` in the breadcrumb
9. Repeat 4-7 for Run > Files > Tale Workspaces
    * `Tale Workspace`
    * `Tale Workspace > depth1`
    * `Tale Workspace > depth1 > depth2`
    * `Tale Workspace > depth1 > depth2 > depth3`
    * Click `depth2` and ensure your breadcrumb matches `Tale Workspace > depth1 > depth2`
10. Repeat 4.7 for Manage > Home
    * `Home`
    * `Home > depth1`
    * `Home > depth1 > depth2`
    * `Home > depth1 > depth2 > depth3`
    * Click `depth2` and ensure your breadcrumb matches `Home > depth1 > depth2`