### PR TITLE
Prevent 'login' as a value for rd

### DIFF
--- a/app/routes/authenticate.js
+++ b/app/routes/authenticate.js
@@ -32,8 +32,8 @@ export default Ember.Route.extend({
           router.set('currentUser', null);
           let returnRoute = this.routerService.router.url;
           
-          // Prevent nexting of multiple "rd" parameters inside each other
-          if (returnRoute.indexOf("?rd=") !== -1) {
+          // Prevent nesting of multiple "rd" parameters, and prevent redirecting to login after login
+          if (returnRoute.indexOf("?rd=") !== -1 || returnRoute.indexOf("login") !== -1) {
             router.transitionTo('login');
           } else {
             router.transitionTo('login', { queryParams: { rd: encodeURIComponent(returnRoute) }});


### PR DESCRIPTION
### Problem
A minor issue, but navigating directly to the `/login` route will populate the `rd` query string parameter with `login`.

When the user logs in, they are redirected to the login page. They can click Login again to get to the browse view, but this extra click is annoying and could confuse new users.

Fixes #423 

### Approach
We already had some logic to detect nested `rd` values, so I've added a clause to this to skip populating the `rd` query parameter with `login`.

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Logout from the Dashboard
    * You should not see an `rd` parameter in the address bar at this time
4. Refresh the page
    * You should still see no `rd` parameter in the address bar
5. Compare with https://dashboard.dev.wholetale.org/login