### PR TITLE
Allow users to edit the Tale Authors field

### DIFF
--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -9,7 +9,7 @@
     <div class="inline fields ui grid">
         <label class="two wide column right aligned">Authors</label>
         <div class="field thirteen wide column">
-            <span>{{model.tale.authors}}</span>
+            {{input value=model.tale.authors readonly=cannotEditTale}}
         </div>
     </div>
 


### PR DESCRIPTION
This is the PR for issue #431. It allows users to modify the Tale Authors field in the metadata view.

To Test:
   1. Launch a Tale
   2. Navigate to the Tale metadata view
   3. Change the Tale authors
   4. Request the Tale from girder
   5. Note that the Tale Authors field has been modified accordingly