### PR TITLE
Add Functionality to Download a Zipped Tale

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -167,16 +167,10 @@ export default Component.extend(FullScreenMixin, {
             return true;
         },
         
-        exportZip(id) {
+        exportTale(id, format) {
           const token = this.get('tokenHandler').getWholeTaleAuthToken();
           let url = `${config.apiUrl}/tale/${id}/export`;
-          window.open(url + '?token=' + token + '&taleFormat=native', '_newtab');
-        },
-
-        exportBag(id) {
-          const token = this.get('tokenHandler').getWholeTaleAuthToken();
-          let url = `${config.apiUrl}/tale/${id}/export`;
-          window.open(url + '?token=' + token + '&taleFormat=bagit', '_newtab');
+          window.location.assign(url + '?token=' + token + '&taleFormat=' + format);
         },
 
         actionMenuClicked() {

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -167,62 +167,22 @@ export default Component.extend(FullScreenMixin, {
             return true;
         },
         
-        exportTale(id) {
-          let self = this;
-          // Asks the girder endpoint for a zipped Tale
-          // This code was adapted from
-          // https://stackoverflow.com/questions/16086162/handle-file-download-from-ajax-post
-          const token = self.get('tokenHandler').getWholeTaleAuthToken();
+        exportZip(id) {
+          const token = this.get('tokenHandler').getWholeTaleAuthToken();
           let url = `${config.apiUrl}/tale/${id}/export`;
-          var xhr = new XMLHttpRequest();
-          xhr.open('GET', url, true);
-          xhr.responseType = 'arraybuffer';
-          xhr.setRequestHeader("Girder-Token", token);
-          self.set('showDimmer', true);
-          xhr.onload = function () {
-              if (this.status === 200) {
-                self.set('showDimmer', false);
-                  var filename = "";
-                  var disposition = xhr.getResponseHeader('Content-Disposition');
-                  if (disposition && disposition.indexOf('attachment') !== -1) {
-                      var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-                      var matches = filenameRegex.exec(disposition);
-                      if (matches != null && matches[1]) filename = matches[1].replace(/['"]/g, '');
-                  }
-                  var type = xhr.getResponseHeader('Content-Type');
-    
-                  var blob = typeof File === 'function'
-                      ? new File([this.response], filename, { type: type })
-                      : new Blob([this.response], { type: type });
-                  if (typeof window.navigator.msSaveBlob !== 'undefined') {
-                      // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
-                      window.navigator.msSaveBlob(blob, filename);
-                  } else {
-                      var URL = window.URL || window.webkitURL;
-                      var downloadUrl = URL.createObjectURL(blob);
-    
-                      if (filename) {
-                          // use HTML5 a[download] attribute to specify filename
-                          var a = document.createElement("a");
-                          // safari doesn't support this yet
-                          if (typeof a.download === 'undefined') {
-                              window.location = downloadUrl;
-                          } else {
-                              a.href = downloadUrl;
-                              a.download = filename;
-                              document.body.appendChild(a);
-                              a.click();
-                          }
-                      } else {
-                          window.location = downloadUrl;
-                      }
-    
-                      setTimeout(function () { URL.revokeObjectURL(downloadUrl); }, 100); // cleanup
-                  }
-              }
-          };
-          xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-          xhr.send();
-        }
+          window.open(url + '?token=' + token + '&taleFormat=native', '_newtab');
+        },
+
+        exportBag(id) {
+          const token = this.get('tokenHandler').getWholeTaleAuthToken();
+          let url = `${config.apiUrl}/tale/${id}/export`;
+          window.open(url + '?token=' + token + '&taleFormat=bagit', '_newtab');
+        },
+
+        actionMenuClicked() {
+          // We need to initialize the export dropdown each time the 
+          // tale action menu is opened
+          $('.ui.left.pointing.dropdown.link.item').dropdown();
+        },
     }
 });

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -8,7 +8,6 @@ import { A } from '@ember/array';
 import { not } from '@ember/object/computed';
 import $ from 'jquery';
 import layout from './template';
-// import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 const O = Object.create.bind(Object);
 
@@ -18,12 +17,14 @@ export default Component.extend(FullScreenMixin, {
     router: service('-routing'),
     internalState: service(),
     apiCall: service('api-call'),
+    tokenHandler: service('token-handler'),
     loadError: false,
     model: null,
     wholeTaleHost: config.wholeTaleHost,
     hasSelectedTaleInstance: false,
     displayTaleInstanceMenu: false,
     workspaceRootId: undefined,
+    showDimmer: false,
 
     session: O({dataSet:A()}),
 
@@ -165,5 +166,63 @@ export default Component.extend(FullScreenMixin, {
         denyDelete() {
             return true;
         },
+        
+        exportTale(id) {
+          let self = this;
+          // Asks the girder endpoint for a zipped Tale
+          // This code was adapted from
+          // https://stackoverflow.com/questions/16086162/handle-file-download-from-ajax-post
+          const token = self.get('tokenHandler').getWholeTaleAuthToken();
+          let url = `${config.apiUrl}/tale/${id}/export`;
+          var xhr = new XMLHttpRequest();
+          xhr.open('POST', url, true);
+          xhr.responseType = 'arraybuffer';
+          xhr.setRequestHeader("Girder-Token", token);
+          self.set('showDimmer', true);
+          xhr.onload = function () {
+              if (this.status === 200) {
+                self.set('showDimmer', false);
+                  var filename = "";
+                  var disposition = xhr.getResponseHeader('Content-Disposition');
+                  if (disposition && disposition.indexOf('attachment') !== -1) {
+                      var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+                      var matches = filenameRegex.exec(disposition);
+                      if (matches != null && matches[1]) filename = matches[1].replace(/['"]/g, '');
+                  }
+                  var type = xhr.getResponseHeader('Content-Type');
+    
+                  var blob = typeof File === 'function'
+                      ? new File([this.response], filename, { type: type })
+                      : new Blob([this.response], { type: type });
+                  if (typeof window.navigator.msSaveBlob !== 'undefined') {
+                      // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
+                      window.navigator.msSaveBlob(blob, filename);
+                  } else {
+                      var URL = window.URL || window.webkitURL;
+                      var downloadUrl = URL.createObjectURL(blob);
+    
+                      if (filename) {
+                          // use HTML5 a[download] attribute to specify filename
+                          var a = document.createElement("a");
+                          // safari doesn't support this yet
+                          if (typeof a.download === 'undefined') {
+                              window.location = downloadUrl;
+                          } else {
+                              a.href = downloadUrl;
+                              a.download = filename;
+                              document.body.appendChild(a);
+                              a.click();
+                          }
+                      } else {
+                          window.location = downloadUrl;
+                      }
+    
+                      setTimeout(function () { URL.revokeObjectURL(downloadUrl); }, 100); // cleanup
+                  }
+              }
+          };
+          xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+          xhr.send();
+        }
     }
 });

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -24,8 +24,6 @@ export default Component.extend(FullScreenMixin, {
     hasSelectedTaleInstance: false,
     displayTaleInstanceMenu: false,
     workspaceRootId: undefined,
-    showDimmer: false,
-
     session: O({dataSet:A()}),
 
     init() {
@@ -171,12 +169,6 @@ export default Component.extend(FullScreenMixin, {
           const token = this.get('tokenHandler').getWholeTaleAuthToken();
           let url = `${config.apiUrl}/tale/${id}/export`;
           window.location.assign(url + '?token=' + token + '&taleFormat=' + format);
-        },
-
-        actionMenuClicked() {
-          // We need to initialize the export dropdown each time the 
-          // tale action menu is opened
-          $('.ui.left.pointing.dropdown.link.item').dropdown();
         },
     }
 });

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -175,7 +175,7 @@ export default Component.extend(FullScreenMixin, {
           const token = self.get('tokenHandler').getWholeTaleAuthToken();
           let url = `${config.apiUrl}/tale/${id}/export`;
           var xhr = new XMLHttpRequest();
-          xhr.open('POST', url, true);
+          xhr.open('GET', url, true);
           xhr.responseType = 'arraybuffer';
           xhr.setRequestHeader("Girder-Token", token);
           self.set('showDimmer', true);

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -1,17 +1,4 @@
 <div class="wt panel manage">
-    {{!-- <div class="wt paddleboard">
-        <h2>
-            <img src="/images/wholetale_logo_sm.png" /> Current Tale
-            {{#if hasSelectedTaleInstance}}
-                <i class="fas fa-expand right floated" style="cursor: pointer;" {{action 'toggleFullscreen'}}></i>
-            {{/if}}
-            {{#if (and (not-eq model.status 0) (and model.iframe (eq internalState.currentInstanceId model._id)))}}
-                <a href="{{model.url}}" target="_blank">
-                    <i class="external alternate right icon" style="cursor: pointer; padding-right: 0.3em; bottom: 4px"></i>
-                </a>
-            {{/if}}
-        </h2>
-    </div> --}}
     {{#unless noInstanceSelected}}
         <div class="wt paddleboard tall header">
             <div class="ui bordlerless menu">
@@ -47,6 +34,9 @@
                                 <div class="ui vertical left menu transition">
                                     <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/run.html" target="_blank">
                                         Read the docs <div class="ui label transparent"><i class="fas fa-book"></i></div>
+                                    </a>
+                                    <a class="item" {{action "exportTale" model.taleId}}>
+                                        Export <div class="ui label transparent"><i class="fas fa-newspaper"></i></div>
                                     </a>
                                     {{#if readyToReleaseFeature}}
                                         <a class="item">
@@ -86,27 +76,6 @@
         </div>
     {{/if}}
 
-    {{!-- <div class="ui {{model._id}} modal" style="display: none">
-        <i class="close icon"></i>
-        <div class="header">
-            Really Delete Instance?
-        </div>
-        <div class="image content">
-            <div class="description">
-                <p>This will permanently delete the '{{model.name}}' instance. Continue?</p>
-            </div>
-        </div>
-        <div class="actions">
-            <div class="ui black deny button" {{action 'denyDelete'}}>
-                No
-            </div>
-            <div class="ui positive right labeled icon button" {{action 'approveDelete' model}}>
-                Yes
-                <i class="checkmark icon"></i>
-            </div>
-        </div>
-    </div> --}}
-
     <div class="ui dataone modal" style="display: none">
         <i class="close icon"></i>
         <div class="header">
@@ -129,4 +98,13 @@
             </div>
         </div>
     </div>
+
+     {{#if showDimmer}}
+    <div class="ui segment" style="position:fixed; top:25%; width:50%; left:25%; height:35%; z-index:999">
+      <div class="ui active dimmer">
+        <div class="ui indeterminate huge text loader">Zipping your Tale</div>
+    </div>
+    <p></p>
+  </div>
+  {{/if}}
 </div>

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -10,7 +10,7 @@
                         <span>{{model.tale.authors}}</span>
                     </div>
                 </div>
-                <div class="right borderless menu" {{action 'actionMenuClicked'}}>
+                <div class="right borderless menu">
                     {{#if readyToReleaseFeature}}
                         <div class="item">
                             <div class="ui blue icon button">
@@ -36,16 +36,12 @@
                                     <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/run.html" target="_blank">
                                         Read the docs <div class="ui label transparent"><i class="fas fa-book"></i></div>
                                     </a>
-                                    <div class="item ui left pointing dropdown link item export">
-                                      Export
-                                      <div class="menu export options">
-                                        <div class="item" {{action "exportTale" model.taleId 'bagit'}}>BagIt</div>
-                                        <div class="item" {{action "exportTale" model.taleId 'native'}}>Zip</div>
-                                      </div>
-                                      <div class="ui label transparent">
-                                        <i class="dropdown icon"></i>
-                                      </div>
-                                    </div>
+                                    <a class="item"  {{action "exportTale" model.taleId 'bagit'}}>
+                                      Export as BagIt <div class="ui label transparent"><i class="fas fa-archive"></i></div>
+                                    </a>
+                                    <a class="item" {{action "exportTale" model.taleId 'native'}}>
+                                      Export as Zip <div class="ui label transparent" ><i class="far fa-file-archive"></i></div>
+                                    </a>
                                     {{#if readyToReleaseFeature}}
                                         <a class="item">
                                             Duplicate Tale <div class="ui label transparent"><i class="fas fa-copy"></i></div>
@@ -106,13 +102,4 @@
             </div>
         </div>
     </div>
-
-     {{#if showDimmer}}
-    <div class="ui segment" style="position:fixed; top:25%; width:50%; left:25%; height:35%; z-index:999">
-      <div class="ui active dimmer">
-        <div class="ui indeterminate huge text loader">Zipping your Tale</div>
-    </div>
-    <p></p>
-  </div>
-  {{/if}}
 </div>

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -36,13 +36,15 @@
                                     <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/run.html" target="_blank">
                                         Read the docs <div class="ui label transparent"><i class="fas fa-book"></i></div>
                                     </a>
-                                    <div class="ui left pointing dropdown link item">
+                                    <div class="item ui left pointing dropdown link item export">
                                       Export
-                                      <div class="menu">
-                                        <div class="item" style="width: 200px; z-index:999;" {{action "exportBag" model.taleId}}>BagIt</div>
-                                        <div class="item" style="width: 200px; z-index:999;" {{action "exportZip" model.taleId}}>Zip</div>
+                                      <div class="menu export options">
+                                        <div class="item" {{action "exportTale" model.taleId 'bagit'}}>BagIt</div>
+                                        <div class="item" {{action "exportTale" model.taleId 'native'}}>Zip</div>
                                       </div>
-                                      <i class="dropdown icon"></i>
+                                      <div class="ui label transparent">
+                                        <i class="dropdown icon"></i>
+                                      </div>
                                     </div>
                                     {{#if readyToReleaseFeature}}
                                         <a class="item">

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -10,7 +10,7 @@
                         <span>{{model.tale.authors}}</span>
                     </div>
                 </div>
-                <div class="right borderless menu">
+                <div class="right borderless menu" {{action 'actionMenuClicked'}}>
                     {{#if readyToReleaseFeature}}
                         <div class="item">
                             <div class="ui blue icon button">
@@ -28,6 +28,7 @@
                             <i class="fas fa-ellipsis-v clickable"></i>
                         </a>
                     </div>
+                    
                     {{#if displayTaleInstanceMenu}}
                         {{#click-outside action=(action (mut displayTaleInstanceMenu) false)}}
                             <div class="tale-instance-menu">
@@ -35,9 +36,14 @@
                                     <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/run.html" target="_blank">
                                         Read the docs <div class="ui label transparent"><i class="fas fa-book"></i></div>
                                     </a>
-                                    <a class="item" {{action "exportTale" model.taleId}}>
-                                        Export <div class="ui label transparent"><i class="fas fa-newspaper"></i></div>
-                                    </a>
+                                    <div class="ui left pointing dropdown link item">
+                                      Export
+                                      <div class="menu">
+                                        <div class="item" style="width: 200px; z-index:999;" {{action "exportBag" model.taleId}}>BagIt</div>
+                                        <div class="item" style="width: 200px; z-index:999;" {{action "exportZip" model.taleId}}>Zip</div>
+                                      </div>
+                                      <i class="dropdown icon"></i>
+                                    </div>
                                     {{#if readyToReleaseFeature}}
                                         <a class="item">
                                             Duplicate Tale <div class="ui label transparent"><i class="fas fa-copy"></i></div>

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -505,6 +505,30 @@ ui.inverted.menu.wt.top {
   background: #2185d0 !important;
 }
 
+/* Export Tale Dropdown */
+
+.ui.left.pointing.dropdown.link.item.export {
+  // Holds the export row
+  width:100%
+}
+
+.ui.left.pointing.dropdown.link.item.export .menu.export.options {
+  // Link that opens more export options
+  width:100%;
+}
+.ui.left.pointing.dropdown.link.item.export .menu.export.options > div {
+  // Each item that is expanded out
+  z-index: 9999; // Make sure the item menu is on top of the environments
+}
+.ui.left.pointing.dropdown.link.item.export .ui.label.transparent {
+  width: 100%;
+}
+.ui.left.pointing.dropdown.link.item.export .ui.label.transparent .dropdown.icon{
+ float: right;
+ width: 10%;
+ margin-left: auto
+}
+
 /* Navigation - Environments panel */
 
 .grey.zone {


### PR DESCRIPTION
### Download Zip
I added a menu item to the three dots dropdown in the Run page. The code for downloading the zip was grabbed from Stack Overflow after failed attempts at doing it my way. Zipping can take some time, and it felt weird not getting any feedback so I put in a semantic ui dimmer that is present until the zip is ready for download.

To Test
   1. Check this branch out
   2. Check out the tale_export branch in girder_wholetale
   3. Deploy
   4. Visit the Run page
   5. Attempt to zip a tale by clicking the zip button in the dropdown
   6. See the dimmer
   7. Get prompted to download the zip (may take a while)

One annoyance I saw is that the dropdown isn't un-selected after selecting an item. I check with semantic-ui and their examples show the same behavior. 