### PR TITLE
Wire up tale rebuild/restart buttons to Run view

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -135,8 +135,13 @@ export default Component.extend(FullScreenMixin, {
             this.set("model", null);
         },
         
-        rebuildTale(id) {
-            this.get('apiCall').rebuildTale(id);
+        // Calls PUT /instance/:id as a noop to restart the instance
+        restartInstance(instance) {
+            this.get('apiCall').restartInstance(instance);
+        },
+        
+        rebuildTale(taleId) {
+            this.get('apiCall').rebuildTale(taleId);
         },
 
         publishTale(modalDialogName, modalContext) {

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -134,6 +134,10 @@ export default Component.extend(FullScreenMixin, {
         stop() {
             this.set("model", null);
         },
+        
+        rebuildTale(id) {
+            this.get('apiCall').rebuildTale(id);
+        },
 
         publishTale(modalDialogName, modalContext) {
             // Open Modal

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -63,7 +63,10 @@
                                         </a>
                                     {{/if}}
                                     <a class="item" onclick={{action 'rebuildTale' model.tale._id}}>
-                                        Rebuild Tale <div class="ui label transparent"><i class="fas fa-cog"></i></div>
+                                        Rebuild Tale <div class="ui label transparent"><i class="fas fa-redo-alt"></i></div>
+                                    </a>
+                                    <a class="item" onclick={{action 'restartInstance' model}}>
+                                        Restart Tale <div class="ui label transparent"><i class="fas fa-sync-alt"></i></div>
                                     </a>
                                     <a class="item" onclick={{action 'toggleFullscreen'}}>
                                         View Fullscreen <div class="ui label transparent"><i class="fas fa-expand"></i></div>

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -55,9 +55,6 @@
                                         <a class="item">
                                             Delete Tale <div class="ui label transparent"><i class="fas fa-trash"></i></div>
                                         </a>
-                                        <a class="item">
-                                            Rebuild Tale <div class="ui label transparent"><i class="fas fa-cog"></i></div>
-                                        </a>
                                         <a class="item" {{action (route-action 'showModal' 'ui/files/publish-modal' publishModalContext )}}>
                                             Publish Tale... <div class="ui label transparent"><i class="fas fa-newspaper"></i></div>
                                         </a>
@@ -65,6 +62,9 @@
                                             Edit Tale Info <div class="ui label transparent"><i class="fas fa-edit"></i></div>
                                         </a>
                                     {{/if}}
+                                    <a class="item" onclick={{action 'rebuildTale' model.tale._id}}>
+                                        Rebuild Tale <div class="ui label transparent"><i class="fas fa-cog"></i></div>
+                                    </a>
                                     <a class="item" onclick={{action 'toggleFullscreen'}}>
                                         View Fullscreen <div class="ui label transparent"><i class="fas fa-expand"></i></div>
                                     </a>

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -354,6 +354,28 @@ export default Service.extend({
         client.send();
     },
     
+    // Calls GET /instance/:id with the given id then immediately
+    // calls PUT as a noop to restart the instance
+    restartInstance(instance) {
+        return $.ajax({
+            url: `${config.apiUrl}/instance/${instance._id}`,
+            method: 'PUT',
+            headers: {
+                'Girder-Token': this.get('tokenHandler').getWholeTaleAuthToken()
+            },
+            data: JSON.stringify(instance),
+            dataType: 'json',
+            contentType: 'application/json',
+            timeout: 3000, // ms
+            success: function(response) {
+                console.log('Restarted Tale instance:', response);
+            },
+            error: function(err) {
+                console.log('Failed to restart Tale instance:', err);
+            }
+        });
+    },
+    
     // Calls PUT /tale/:id/build with the given id
     rebuildTale(taleId) {
         return $.ajax({
@@ -370,5 +392,5 @@ export default Service.extend({
                 console.log('Failed to build Tale image:', err);
             }
         });
-    }
+    },
 });

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -1,5 +1,6 @@
 import config from '../config/environment';
 import Service from '@ember/service';
+import $ from 'jquery';
 import {
     inject as service
 } from '@ember/service';
@@ -351,5 +352,23 @@ export default Service.extend({
         client.addEventListener("error", fail);
 
         client.send();
+    },
+    
+    // Calls PUT /tale/:id/build with the given id
+    rebuildTale(taleId) {
+        return $.ajax({
+            url: `${config.apiUrl}/tale/${taleId}/build`,
+            method: 'PUT',
+            headers: {
+                'Girder-Token': this.get('tokenHandler').getWholeTaleAuthToken()
+            },
+            timeout: 3000, // ms
+            success: function(response) {
+                console.log('Building Tale image:', response);
+            },
+            error: function(err) {
+                console.log('Failed to build Tale image:', err);
+            }
+        });
     }
 });


### PR DESCRIPTION
### Problem
The user needs a rudimentary way to initiate a Rebuild or Restart of their running Tale.

### Approach
Since we already have done much the API work, this PR wires up the new endpoints to buttons on the Dashboard's Run view.

### How to Test
Prerequisites:
1. Run https://github.com/whole-tale/deploy-dev/tree/repo2docker
2. Comment out or remove all calls to `/image/:id/build`, as this endpoint no longer exists
3. `make clean && make dev`
    * This will delete and recreate all of your Tale images, as the underlying format has changed
    * At the end of this operation, you should have 4 environments available: `Jupyter Classic`, `RStudio`, `RStudio (rocker/geospatial)`, and `JupyterLab`
4. Run alongside https://github.com/whole-tale/girder_wholetale/pull/254 and https://github.com/whole-tale/gwvolman/pull/43

Test Steps:
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Compose and launch a Tale, if you haven't already
4. Navigate to the Run view, and make sure a running Tale is selected
5. At the far right, click the vertical ellipsis
    * You should see a dropdown appear with more options
    * You should see `Rebuild Tale` offered as an option
    * You should see `Restart Tale` offered as an option
6. Open a terminal and watch the logs for `gwvolman`: `docker logs -f celery_worker`
7. Click the `Restart Tale` button and watch the log
    * You should see that a Docker image build is kicked off for the Tale
8. Once the build finishes, click the `Restart Tale` endpoint
    * If the underlying image *did not* change as a result of the build operation, it seems that Docker is smart enough to avoid restarting during an update if the update was a noop
    * If the underlying digest *did* change as a result of the build operation, you should see that the container is restarted to use the new image