### PR TITLE
Bring back the 'Remove' button for datasets in the Manage view

### DIFF
--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -40,11 +40,11 @@
                                 <a class="item" href="{{apiUrl}}/{{item._modelType}}/{{item.id}}/download?contentDisposition=attachment">
                                     <i class="download icon"></i> Download
                                 </a>
-                                {{#if (gt model.tale._accessLevel 0)}}
+                                {{#unless (or notInManagePage (lt model.tale._accessLevel 1))}}
                                 <a class="item" href="#" {{action "removeDataset" item.id}}>
                                     <i class="trash icon"></i> Remove
                                 </a>
-                                {{/if}}
+                                {{/unless}}
                             </div>
                         {{/ui-dropdown}}
                     </td>


### PR DESCRIPTION
### Problem
User is unable to delete/remove/disassociate datasets that they had previously registered.

### Approach
This component is very complex and is used in multiple views that make up a significant portion of the WholeTale Dashboard. The slightest change here can have rippling effects on other parts of the dashboard.

As a result, I've tried to minimize my changes to this component here. If we can establish of list of which views should offer which functions, I'm sure I could clean up this logic to make the different modes of operation a bit more clear.

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Manage > Data
4. Register a dataset, if you haven't already
5. Click the dropdown beside the dataset you just registered
6. Click "Remove" to disassociate this data from your user
    * You should see the data disappear from the view