### PR TITLE
Allow Users to Set Tale Licenses

### DIFF
--- a/app/components/ui/tale-tab-metadata/component.js
+++ b/app/components/ui/tale-tab-metadata/component.js
@@ -17,6 +17,7 @@ const taleStatus = Object.create({
 export default Component.extend({
   apiHost: config.apiHost,
   environments: [],
+  licenses: [],
   model: null,
   init() {
     this._super(...arguments);
@@ -27,18 +28,36 @@ export default Component.extend({
       component.set('environments', images);
       component.selectDefaultImageId();
     });
+
+    // Fetch licenses for users to select
+    $.getJSON(this.get('apiHost') + '/api/v1/license/').then(function(licenses) {
+      component.set('licenses', licenses);
+      component.selectDefaultLicense();
+    });
   },
   
   didRender() {
     // Enable the environment dropdown functionality
     $('.ui.dropdown').dropdown();
     this.selectDefaultImageId();
+    $('.ui.icon.selection.dropdown.license').dropdown();
+    this.selectDefaultLicense();
   },
   
   selectDefaultImageId() {
     // Select the current imageId by default
     const selectedImageId = this.get('model').get('tale').get('imageId');
     $('.ui.dropdown').dropdown('set selected', selectedImageId);
+  },
+
+  selectDefaultLicense() {
+    // Select the license that the Tale currently has
+    const selectedLicense = this.get('model').get('tale').get('license');
+    this.get('licenses').forEach((license) => {
+      if (license.spdx == selectedLicense) {
+        $('.ui.icon.selection.dropdown.license').dropdown('set selected', license.spdx);
+      }
+    })
   },
   
   canEditTale: computed('model.tale._accessLevel', function () {
@@ -59,6 +78,11 @@ export default Component.extend({
     setTaleEnvironment: function(selected) {
       const tale = this.get('model').get('tale');
       tale.set('imageId', selected);
+    },
+
+    setTaleLicense: function(selected) {
+      const tale = this.get('model').get('tale');
+      tale.set('license', selected);
     },
   }
 });

--- a/app/components/ui/tale-tab-metadata/component.js
+++ b/app/components/ui/tale-tab-metadata/component.js
@@ -52,7 +52,7 @@ export default Component.extend({
 
   selectDefaultLicense() {
     // Select the license that the Tale currently has
-    const selectedLicense = this.get('model').get('tale').get('license');
+    const selectedLicense = this.get('model').get('tale').get('licenseSPDX');
     this.get('licenses').forEach((license) => {
       if (license.spdx == selectedLicense) {
         $('.ui.icon.selection.dropdown.license').dropdown('set selected', license.spdx);
@@ -82,7 +82,7 @@ export default Component.extend({
 
     setTaleLicense: function(selected) {
       const tale = this.get('model').get('tale');
-      tale.set('license', selected);
+      tale.set('licenseSPDX', selected);
     },
   }
 });

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -39,6 +39,24 @@
     </div>
 
     <div class="inline fields ui grid">
+        <label class="two wide column right aligned">License</label>
+        <div class="field thirteen wide column">
+            <div id="licenseDropdown" class="ui icon selection dropdown license {{if (eq licenses.length 0) "loading"}}">
+                <input name="TaleLicenseSPDX" type="hidden" onchange={{action "setTaleLicense" value="target.value"}}>
+                <i class="dropdown icon"></i>
+                <div class="default text"> Choose a license...</div>
+                <div class="menu">
+                    {{#each licenses as |license|}}
+                        <div class="item" data-value={{license.spdx}}>
+                            {{license.name}}
+                        </div>
+                    {{/each}}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="inline fields ui grid">
         <label class="two wide column right aligned">Date Created</label>
         <div class="field thirteen wide column">
             <span>{{model.tale.created}}</span>

--- a/app/models/tale.js
+++ b/app/models/tale.js
@@ -18,5 +18,6 @@ export default DS.Model.extend({
   "title": DS.attr('string'),
   "updated": DS.attr('date'),
   "dataSet": DS.attr(),
-  "folderId": DS.attr('string')
+  "folderId": DS.attr('string'),
+  "license": DS.attr('string')
 });

--- a/app/models/tale.js
+++ b/app/models/tale.js
@@ -19,5 +19,5 @@ export default DS.Model.extend({
   "updated": DS.attr('date'),
   "dataSet": DS.attr(),
   "folderId": DS.attr('string'),
-  "license": DS.attr('string')
+  "licenseSPDX": DS.attr('string')
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -332,6 +332,10 @@ div.upload.progress {
   }
 }
 
+#licenseDropdown {
+    width: 100%;
+}
+
 p,
 .description,
 .item {


### PR DESCRIPTION
### Tale Licenses

This PR adds a feature that allows users to select licenses for their Tales. 

Highlights:
   1. User can select the license in the metadata tab under Run
   2. Tales default to CC-BY (see branch in girder_wholetale)
   3. Dropdown automatically selects current Tale license


#### Testing
   1. Check this branch out
   2. Check out tale_license in girder_wholetale
   3. Deploy
   4. Create a new Tale
   5. Verify it has CC-BY via Girder API or metadata tab
   6. Navigate to Run > metadata
   7. Confirm CC-BY is selected
   8. Change the license and save
   9. Confirm new license state via Girder API or refresh the page & make sure it is selected