### PR TITLE
Notification widget to receive status updates on "Rebuild"

### DIFF
--- a/app/components/dashboard/unified-view/template.hbs
+++ b/app/components/dashboard/unified-view/template.hbs
@@ -8,3 +8,5 @@
     </div>
   </div>
 </div>
+
+{{ui/notification-stream}}

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import config from '../../../config/environment';
 import layout from './template';
+import JSONBeautify from 'npm:json-beautify';
 
 const EventSource = window.EventSourcePolyfill;
 
@@ -44,14 +45,8 @@ export default Component.extend({
         events.push(event);
         this.set('events', events);
         let json = JSON.parse(event.data)
-        if (json.type == 'job_created' && json.data.title == 'Build Tale Image') {
-            alert("Building Tale Image: " + json.data.args[0]);
-        } else if (json.type == 'job_status') {
-            alert("Tale Building: " + json.data.args[0] + "\nStatus is now " + json.data.status);
-        } else {
-            alert("Unknown job type: " + json);
-            console.log(json);
-        }
+        console.log("JSON data recv'd:", json);
+        alert(event.data);
     },
     onError(error) {
         console.log("EventSource failed.");

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -1,0 +1,69 @@
+// app/pods/components/markdown-component/component.js
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import config from '../../../config/environment';
+import layout from './template';
+
+const EventSource = window.EventSourcePolyfill;
+
+export default Component.extend({
+    layout,
+    tokenHandler: service('token-handler'),
+    
+    apiHost: config.apiHost,
+    events: [
+        { 'subject': 'Tale A', 'message': 'build now in progress.', 'date': new Date(), 'counter': 0, 'icon': 'fa-cog fa-spin' },
+        { 'subject': 'Tale B', 'message': 'build now in progress.', 'date': new Date(), 'counter': 1 },
+        { 'subject': 'Tale A', 'message': 'build now in progress.', 'date': new Date(), 'counter': 2 },
+    ],
+    source: null,
+    
+    init() {
+        const self = this;
+        let token = this.get('tokenHandler').getWholeTaleAuthToken();
+        let endpoint = self.get('apiHost') + '/api/v1/notification/stream';
+        let es = new EventSource(endpoint, {
+          headers: {
+            'Girder-Token': token
+          }
+        });
+        
+        es.onopen = self.onOpen.bind(self);
+        es.onmessage = self.onMessage.bind(self);
+        es.onerror = self.onError.bind(self);
+        
+        self.set('source', es);
+        self.set('events', []);
+    },
+    onOpen() {
+        console.log("Connection to server opened.")
+    },
+    onMessage(event) {
+        console.log("Message recv'd:", event);
+        let events = this.get('events');
+        events.push(event);
+        this.set('events', events);
+        let json = JSON.parse(event.data)
+        if (json.type == 'job_created' && json.data.title == 'Build Tale Image') {
+            alert("Building Tale Image: " + json.data.args[0]);
+        } else if (json.type == 'job_status') {
+            alert("Tale Building: " + json.data.args[0] + "\nStatus is now " + json.data.status);
+        } else {
+            alert("Unknown job type: " + json);
+            console.log(json);
+        }
+    },
+    onError(error) {
+        console.log("EventSource failed.");
+        if (this.get('source').readyState == EventSource.CLOSED) return;
+        console.error(error);
+    },
+    generateEvent() {
+        let counter = this.get('events').length;
+        return { 'subject': 'Tale A', 'message': 'build now in progress.', 'date': new Date(), 'counter': counter };
+    },
+    pushGeneratedEvent() {
+        this.get('events').push(this.generateEvent());
+    }
+});
+ 

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -1,17 +1,12 @@
 // app/pods/components/markdown-component/component.js
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
-import config from '../../../config/environment';
 import layout from './template';
-import JSONBeautify from 'npm:json-beautify';
-
-const EventSource = window.EventSourcePolyfill;
 
 export default Component.extend({
     layout,
-    tokenHandler: service('token-handler'),
+    notificationStream: service('notification-stream'),
     
-    apiHost: config.apiHost,
     events: [
         { 'subject': 'Tale A', 'message': 'build now in progress.', 'date': new Date(), 'counter': 0, 'icon': 'fa-cog fa-spin' },
         { 'subject': 'Tale B', 'message': 'build now in progress.', 'date': new Date(), 'counter': 1 },
@@ -19,46 +14,28 @@ export default Component.extend({
     ],
     source: null,
     
-    init() {
+    didInsertElement() {
         const self = this;
-        let token = this.get('tokenHandler').getWholeTaleAuthToken();
-        let endpoint = self.get('apiHost') + '/api/v1/notification/stream';
-        let es = new EventSource(endpoint, {
-          headers: {
-            'Girder-Token': token
-          }
-        });
+        self.set('source', this.get('notificationStream').connect());
+        //self.set('events', []);
+    },
+    willDestroyElement() {
+        const self = this;
+        let source = self.get('source');
+        if (source) {
+            source.close();
+        }
         
-        es.onopen = self.onOpen.bind(self);
-        es.onmessage = self.onMessage.bind(self);
-        es.onerror = self.onError.bind(self);
-        
-        self.set('source', es);
-        self.set('events', []);
+        self.set('source', null);
+        //self.set('events', []);
     },
-    onOpen() {
-        console.log("Connection to server opened.")
-    },
-    onMessage(event) {
-        console.log("Message recv'd:", event);
-        let events = this.get('events');
-        events.push(event);
-        this.set('events', events);
-        let json = JSON.parse(event.data)
-        console.log("JSON data recv'd:", json);
-        alert(event.data);
-    },
-    onError(error) {
-        console.log("EventSource failed.");
-        if (this.get('source').readyState == EventSource.CLOSED) return;
-        console.error(error);
-    },
-    generateEvent() {
+    generateEvent(taleName, message) {
         let counter = this.get('events').length;
-        return { 'subject': 'Tale A', 'message': 'build now in progress.', 'date': new Date(), 'counter': counter };
+        return { 'subject': taleName, 'message': message, 'date': new Date(), 'counter': counter };
     },
     pushGeneratedEvent() {
-        this.get('events').push(this.generateEvent());
+        let event = this.generateEvent('Tale A', 'build now in progress.');
+        this.get('events').push(event);
     }
 });
  

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -67,7 +67,6 @@ export default Component.extend({
         
     fetchLogs() {
         const self = this;
-        const ansi_up = new AnsiUp();
 
         const event = self.get('selectedEvent');
         self.get('store').findRecord('job', event.json.data.imageInfo.jobId).then(job => {

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -51,7 +51,7 @@ export default Component.extend({
         const self = this;
         // Parse event data (tale) into JSON
         event.json = JSON.parse(event.data);
-        event.created = new Date(event.json._girderTime * 1000).toLocaleString();
+        event.created = new Date(event.json.time).toLocaleString();
         //console.log("Message recv'd:", event);
         
         // Push new event data

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -1,24 +1,34 @@
-// app/pods/components/markdown-component/component.js
+// app/pods/components/notification-stream/component.js
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
+import { A } from '@ember/array';
 import layout from './template';
+
+// Load a polyfill for EventSource to allow passing custom headers (e.g. token)
+const EventSource = window.EventSourcePolyfill;
 
 export default Component.extend({
     layout,
     notificationStream: service('notification-stream'),
     
-    events: [
-        { 'subject': 'Tale A', 'message': 'build now in progress.', 'date': new Date(), 'counter': 0, 'icon': 'fa-cog fa-spin' },
-        { 'subject': 'Tale B', 'message': 'build now in progress.', 'date': new Date(), 'counter': 1 },
-        { 'subject': 'Tale A', 'message': 'build now in progress.', 'date': new Date(), 'counter': 2 },
-    ],
+    events: A([]),
     source: null,
     
     didInsertElement() {
         const self = this;
-        self.set('source', this.get('notificationStream').connect());
-        //self.set('events', []);
+        const source = self.get('notificationStream').connect();
+        
+        source.onopen = () => console.log("Connected to event server.");
+        source.onmessage = self.onMessage.bind(this);
+        source.onerror = (err) => {
+            console.log("EventSource failed:", err);
+            this.get('notificationStream').close();
+        };
+        
+        self.set('source', source);
+        self.set('events', A([]));
     },
+    
     willDestroyElement() {
         const self = this;
         let source = self.get('source');
@@ -26,16 +36,40 @@ export default Component.extend({
             source.close();
         }
         
+        self.set('events', A([]));
         self.set('source', null);
-        //self.set('events', []);
     },
+    
     generateEvent(taleName, message) {
-        let counter = this.get('events').length;
+        const self = this;
+        let counter = self.get('events').length;
         return { 'subject': taleName, 'message': message, 'date': new Date(), 'counter': counter };
     },
-    pushGeneratedEvent() {
-        let event = this.generateEvent('Tale A', 'build now in progress.');
-        this.get('events').push(event);
+    
+    onMessage(event) {
+        const self = this;
+        // Parse event data (tale) into JSON
+        event.json = JSON.parse(event.data);
+        event.created = new Date(event.json._girderTime * 1000).toLocaleString();
+        //console.log("Message recv'd:", event);
+        
+        // Push new event data
+        let events = self.get('events');
+        if (event.json.type == 'wt_image_build_status') {
+            events.unshiftObject(event);
+            self.set('events', events);
+            console.log("New event:", events);
+        } else {
+            console.log("Ignoring event:", event);
+        }
+    },
+    
+    actions: {
+        markAllAsRead() {
+            const self = this;
+            self.get('notificationStream').markAllAsRead();
+            self.set('events', A([]));
+        }
     }
 });
  

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -5,8 +5,8 @@
           position: fixed;
           z-index: 1;
           top: 32px;
-          left: 75vw;
-          width: 24vw;
+          left: 70vw;
+          width: 26vw;
           background: #fff;
           box-shadow: 0 0 4px rgba(0,0,0,.2);
           border: 1px solid rgba(0,0,0,.2);
@@ -98,7 +98,7 @@
     {{#if selectedEventLogs}}
       <pre>{{selectedEventLogs}}</pre>
     {{else}}
-      <div class="ui segment" style="max-height:20vh">
+      <div class="ui segment" style="min-height:20vh">
         <div class="ui active inverted dimmer">
           <div class="ui text loader">Loading</div>
         </div>

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -95,7 +95,16 @@
     Log Viewer
   </div>
   <div class="scrolling content">
-    <pre>{{selectedEventLogs}}</pre>
+    {{#if selectedEventLogs}}
+      <pre>{{selectedEventLogs}}</pre>
+    {{else}}
+      <div class="ui segment" style="max-height:20vh">
+        <div class="ui active inverted dimmer">
+          <div class="ui text loader">Loading</div>
+        </div>
+        <p></p>
+      </div>
+    {{/if}}
   </div>
   <div class="actions">
     <div class="ui button" {{action 'closeLogViewerModal'}}>Done</div>

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -17,53 +17,53 @@
   </style>
   <div class="ui feed computer tablet only" id="event-notification-stream">
       
-      <button class="ui button" {{action 'markAllAsRead'}}>Mark All as Read</button>
-      
-      {{#each events as |event index|}}
-        {{!-- Ignore everything but build events --}}
-        {{#if (eq event.json.type 'wt_image_build_status')}}
-          {{#if (gt index 0)}}<hr />{{/if}}
-          <div class="event">
-            <div class="label">
-              <i class="fas fa-2x fa-fw fa-wrench event-icon"></i>
+    <button class="ui button fluid" {{action 'markAllAsRead'}}>Mark All as Read</button>
+    
+    {{#each events as |event index|}}
+      {{!-- Ignore everything but build events --}}
+      {{#if (eq event.json.type 'wt_image_build_status')}}
+        {{#if (gt index 0)}}<hr />{{/if}}
+        <div class="event">
+          <div class="label">
+            <i class="fas fa-2x fa-fw fa-wrench event-icon"></i>
+          </div>
+          <div class="content">
+            <div class="summary">
+              <a class="user">
+                {{event.json.data._id}}
+              </a>
+              {{event.json.data.title}}
+              <div class="date">
+                {{event.created}}
+              </div>
             </div>
-            <div class="content">
-              <div class="summary">
-                  <a class="user">
-                    {{event.json.data._id}}
+            <div class="ui grid">
+              <div class="six wide column">
+                <div class="meta">
+                  <a class="status" style="cursor: not-allowed;">
+                    {{#if (eq event.json.data.imageInfo.status 0)}}
+                      <i class="icon fas fa-fw fa-ban"></i> INVALID
+                    {{else if (eq event.json.data.imageInfo.status 1)}}
+                      <i class="icon fas fa-fw fa-times"></i> UNAVAILABLE
+                    {{else if (eq event.json.data.imageInfo.status 2)}}
+                      <i class="icon fas fa-fw fa-cog fa-spin"></i> BUILDING
+                    {{else if (eq event.json.data.imageInfo.status 3)}}
+                      <i class="icon fas fa-fw fa-check"></i> SUCCESS
+                    {{/if}}
                   </a>
-                {{event.json.data.title}}
-                <div class="date">
-                  {{event.created}}
                 </div>
               </div>
-              <div class="ui grid">
-                <div class="six wide column">
-                  <div class="meta">
-                    <a class="status" style="cursor: not-allowed;">
-                      {{#if (eq event.json.data.imageInfo.status 0)}}
-                        <i class="icon fas fa-fw fa-ban"></i> INVALID
-                      {{else if (eq event.json.data.imageInfo.status 1)}}
-                        <i class="icon fas fa-fw fa-times"></i> UNAVAILABLE
-                      {{else if (eq event.json.data.imageInfo.status 2)}}
-                        <i class="icon fas fa-fw fa-cog fa-spin"></i> BUILDING
-                      {{else if (eq event.json.data.imageInfo.status 3)}}
-                        <i class="icon fas fa-fw fa-check"></i> SUCCESS
-                      {{/if}}
-                    </a>
-                  </div>
-                </div>
-                <div class="six wide column">
-                  <div class="meta">
-                    <a class="logs" style="cursor: not-allowed;">
-                      View Logs
-                    </a>
-                  </div>
+              <div class="six wide column">
+                <div class="meta">
+                  <a class="logs" style="cursor: not-allowed;">
+                    View Logs
+                  </a>
                 </div>
               </div>
             </div>
           </div>
-        {{/if}}
-      {{/each}}
+        </div>
+      {{/if}}
+    {{/each}}
   </div>
 {{/with}}

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -1,42 +1,69 @@
-<style>
-    #event-notification-stream {
-        position: fixed;
-        top:32px;
-        left:75vw;
-        background: white;
-        border: solid black 2px;
-        border-radius: 5px;
-    }
-    .event-icon{
-        margin: 15px 12px;
-    }
-</style>
-
-<div class="ui feed computer tablet only" id="event-notification-stream">
-    {{#each events as |event index|}}
-      {{#if (gt index 0)}}<hr />{{/if}}
-      <div class="event">
-        <div class="label">
-            {{!-- {{if event.icon event.icon}} --}}
-          <i class="fas fa-2x fa-fw event-icon fa-cog fa-spin"></i>
-        </div>
-        <div class="content">
-          <div class="summary">
-            <a class="user">
-              {{event.data.args}}
-            </a> {{event.data.title}}
-            <div class="date">
-              {{event.data.created}}
+{{#with events}}
+  <style>
+      /* TODO: Move these to .css once finalized */
+      #event-notification-stream {
+          position: fixed;
+          top:32px;
+          left:75vw;
+          background: white;
+          border: solid black 2px;
+          border-radius: 5px;
+          max-height: 40vh;
+          overflow-y: auto;
+      }
+      .event-icon{
+          margin: 15px 12px;
+      }
+  </style>
+  <div class="ui feed computer tablet only" id="event-notification-stream">
+      
+      <button class="ui button" {{action 'markAllAsRead'}}>Mark All as Read</button>
+      
+      {{#each events as |event index|}}
+        {{!-- Ignore everything but build events --}}
+        {{#if (eq event.json.type 'wt_image_build_status')}}
+          {{#if (gt index 0)}}<hr />{{/if}}
+          <div class="event">
+            <div class="label">
+              <i class="fas fa-2x fa-fw fa-wrench event-icon"></i>
+            </div>
+            <div class="content">
+              <div class="summary">
+                  <a class="user">
+                    {{event.json.data._id}}
+                  </a>
+                {{event.json.data.title}}
+                <div class="date">
+                  {{event.created}}
+                </div>
+              </div>
+              <div class="ui grid">
+                <div class="six wide column">
+                  <div class="meta">
+                    <a class="status" style="cursor: not-allowed;">
+                      {{#if (eq event.json.data.imageInfo.status 0)}}
+                        <i class="icon fas fa-fw fa-ban"></i> INVALID
+                      {{else if (eq event.json.data.imageInfo.status 1)}}
+                        <i class="icon fas fa-fw fa-times"></i> UNAVAILABLE
+                      {{else if (eq event.json.data.imageInfo.status 2)}}
+                        <i class="icon fas fa-fw fa-cog fa-spin"></i> BUILDING
+                      {{else if (eq event.json.data.imageInfo.status 3)}}
+                        <i class="icon fas fa-fw fa-check"></i> SUCCESS
+                      {{/if}}
+                    </a>
+                  </div>
+                </div>
+                <div class="six wide column">
+                  <div class="meta">
+                    <a class="logs" style="cursor: not-allowed;">
+                      View Logs
+                    </a>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
-          {{!--<div class="meta">
-            <a class="like">
-              <i class="like icon"></i> {{event.counter}} Cancels
-            </a>
-          </div>--}}
-        </div>
-      </div>
-    {{/each}}
-    
-    <button onclick={{action 'pushGeneratedEvent'}}></button>
-</div>
+        {{/if}}
+      {{/each}}
+  </div>
+{{/with}}

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -17,23 +17,26 @@
       {{#if (gt index 0)}}<hr />{{/if}}
       <div class="event">
         <div class="label">
-          <i class="fas fa-2x fa-fw event-icon {{if event.icon event.icon}}"></i>
+            {{!-- {{if event.icon event.icon}} --}}
+          <i class="fas fa-2x fa-fw event-icon fa-cog fa-spin"></i>
         </div>
         <div class="content">
           <div class="summary">
             <a class="user">
-              {{event.subject}}
-            </a> {{event.message}}
+              {{event.data.args}}
+            </a> {{event.data.title}}
             <div class="date">
-              {{event.date}}
+              {{event.data.created}}
             </div>
           </div>
-          <div class="meta">
+          {{!--<div class="meta">
             <a class="like">
               <i class="like icon"></i> {{event.counter}} Cancels
             </a>
-          </div>
+          </div>--}}
         </div>
       </div>
     {{/each}}
+    
+    <button onclick={{action 'pushGeneratedEvent'}}></button>
 </div>

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -1,0 +1,39 @@
+<style>
+    #event-notification-stream {
+        position: fixed;
+        top:32px;
+        left:75vw;
+        background: white;
+        border: solid black 2px;
+        border-radius: 5px;
+    }
+    .event-icon{
+        margin: 15px 12px;
+    }
+</style>
+
+<div class="ui feed computer tablet only" id="event-notification-stream">
+    {{#each events as |event index|}}
+      {{#if (gt index 0)}}<hr />{{/if}}
+      <div class="event">
+        <div class="label">
+          <i class="fas fa-2x fa-fw event-icon {{if event.icon event.icon}}"></i>
+        </div>
+        <div class="content">
+          <div class="summary">
+            <a class="user">
+              {{event.subject}}
+            </a> {{event.message}}
+            <div class="date">
+              {{event.date}}
+            </div>
+          </div>
+          <div class="meta">
+            <a class="like">
+              <i class="like icon"></i> {{event.counter}} Cancels
+            </a>
+          </div>
+        </div>
+      </div>
+    {{/each}}
+</div>

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -94,7 +94,7 @@
     Log Viewer
   </div>
   <div class="scrolling content">
-    <p>{{selectedEventLogs}}</p>
+    <pre>{{selectedEventLogs}}</pre>
   </div>
   <div class="actions">
     <div class="ui button" {{action 'closeLogViewerModal'}}>Ok</div>

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -5,11 +5,17 @@
           position: fixed;
           top:32px;
           left:75vw;
-          background: white;
-          border: solid black 2px;
-          border-radius: 5px;
+          width:24vw;
+          background: #fff;
+          box-shadow: 0 0 4px rgba(0,0,0,.2);
+          border: 1px solid rgba(0,0,0,.2);
+          border-radius: 1rem;
+          padding-bottom: 15px;
           max-height: 40vh;
           overflow-y: auto;
+      }
+      #ack-all-button {
+          border-radius: 1rem 1rem 0 0;
       }
       .event-icon{
           margin: 15px 12px;
@@ -17,7 +23,7 @@
   </style>
   <div class="ui feed computer tablet only" id="event-notification-stream">
       
-    <button class="ui button fluid" {{action 'markAllAsRead'}}>Mark All as Read</button>
+    <button class="ui button fluid" id="ack-all-button" {{action 'markAllAsRead'}}>Mark All as Read</button>
     
     {{#each events as |event index|}}
       {{!-- Ignore everything but build events --}}
@@ -29,18 +35,30 @@
           </div>
           <div class="content">
             <div class="summary">
+              {{!-- TODO: Link to "/run/:tale_id" view once that is finished --}}
+              {{!-- {{event.json.data._id}} --}}
               <a class="user">
-                {{event.json.data._id}}
+                {{truncate-name event.json.data.title}}
               </a>
-              {{event.json.data.title}}
+              {{!--<div>
+                {{#if (eq event.json.data.imageInfo.status 0)}}
+                  Tale image is invalid.
+                {{else if (eq event.json.data.imageInfo.status 1)}}
+                  Tale image is unavailable.
+                {{else if (eq event.json.data.imageInfo.status 2)}}
+                  Building tale image...
+                {{else if (eq event.json.data.imageInfo.status 3)}}
+                  Tale image built successfully!
+                {{/if}}
+              </div>--}}
               <div class="date">
                 {{event.created}}
               </div>
             </div>
             <div class="ui grid">
-              <div class="six wide column">
+              <div class="eight wide column">
                 <div class="meta">
-                  <a class="status" style="cursor: not-allowed;">
+                  <a class="status" {{action 'openLogViewerModal' event}}>
                     {{#if (eq event.json.data.imageInfo.status 0)}}
                       <i class="icon fas fa-fw fa-ban"></i> INVALID
                     {{else if (eq event.json.data.imageInfo.status 1)}}
@@ -53,11 +71,13 @@
                   </a>
                 </div>
               </div>
-              <div class="six wide column">
+              <div class="eight wide column">
                 <div class="meta">
-                  <a class="logs" style="cursor: not-allowed;">
-                    View Logs
-                  </a>
+                  {{#if (eq event.json.data.imageInfo.status 3)}}
+                    <a class="logs" {{action 'restartTaleInstance' event.json.data}}>
+                      Restart to Use New Image
+                    </a>
+                  {{/if}}
                 </div>
               </div>
             </div>
@@ -67,3 +87,16 @@
     {{/each}}
   </div>
 {{/with}}
+
+<div id="log-viewer-modal" class="ui modal">
+  <div class="ui icon header">
+    <i class="wrench icon"></i>
+    Log Viewer
+  </div>
+  <div class="scrolling content">
+    <p>{{selectedEventLogs}}</p>
+  </div>
+  <div class="actions">
+    <div class="ui button" {{action 'closeLogViewerModal'}}>Ok</div>
+  </div>
+</div>

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -3,9 +3,10 @@
       /* TODO: Move these to .css once finalized */
       #event-notification-stream {
           position: fixed;
-          top:32px;
-          left:75vw;
-          width:24vw;
+          z-index: 1;
+          top: 32px;
+          left: 75vw;
+          width: 24vw;
           background: #fff;
           box-shadow: 0 0 4px rgba(0,0,0,.2);
           border: 1px solid rgba(0,0,0,.2);
@@ -97,6 +98,6 @@
     <pre>{{selectedEventLogs}}</pre>
   </div>
   <div class="actions">
-    <div class="ui button" {{action 'closeLogViewerModal'}}>Ok</div>
+    <div class="ui button" {{action 'closeLogViewerModal'}}>Done</div>
   </div>
 </div>

--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -23,14 +23,15 @@ export default Service.extend({
         
         // Only fetch message since our last acknowledgement
         const lastRead = localStorage.getItem('lastRead');
-        const suffix = lastRead ? '?timeout=40&since=' + encodeURIComponent(lastRead) : '?timeout=40';
+        const suffix = lastRead ? '?timeout=3600&since=' + encodeURIComponent(lastRead) : '?timeout=3600';
         
         // Connect to Girder's notification stream endpoint for SSE
         console.log("Connecting...");
         const endpoint = self.get('apiHost') + '/api/v1/notification/stream' + suffix;
         const newSource = new EventSource(endpoint, {
           headers: {
-            'Girder-Token': self.get('tokenHandler').getWholeTaleAuthToken()
+            'Girder-Token': self.get('tokenHandler').getWholeTaleAuthToken(),
+            'Connection': 'Keep-Alive'
           }
         });
         

--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -23,7 +23,7 @@ export default Service.extend({
         
         // Only fetch message since our last acknowledgement
         const lastRead = localStorage.getItem('lastRead');
-        const suffix = lastRead ? '?since=' + encodeURIComponent(lastRead) : '';
+        const suffix = lastRead ? '?timeout=9999999999&since=' + encodeURIComponent(lastRead) : '?timeout=9999999999';
         
         // Connect to Girder's notification stream endpoint for SSE
         console.log("Connecting...");

--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -7,10 +7,10 @@ import config from '../config/environment';
 const EventSource = window.EventSourcePolyfill;
 
 export default Service.extend({
-    tokenHandler: service('token-handler'),
     apiHost: config.apiHost,
+    tokenHandler: service('token-handler'),
+    
     source: null,
-    lastRead: localStorage.getItem('lastRead'),
     
     /* Connect if not connected, otherwise return existing instance */
     connect() {
@@ -22,7 +22,7 @@ export default Service.extend({
         }
         
         // Only fetch message since our last acknowledgement
-        const lastRead = this.get('lastRead');
+        const lastRead = localStorage.getItem('lastRead');
         const suffix = lastRead ? '?since=' + encodeURIComponent(lastRead) : '';
         
         // Connect to Girder's notification stream endpoint for SSE
@@ -40,9 +40,8 @@ export default Service.extend({
     },
     
     markAllAsRead() {
-        let rightNow = Math.round(new Date().getTime() / 1000);;
+        let rightNow = Math.round(new Date().getTime() / 1000);
         console.log('Setting lastRead = ', rightNow);
-        this.set('lastRead', rightNow); 
         localStorage.setItem('lastRead', rightNow);
         
         // Reconnect

--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -23,7 +23,7 @@ export default Service.extend({
         
         // Only fetch message since our last acknowledgement
         const lastRead = localStorage.getItem('lastRead');
-        const suffix = lastRead ? '?timeout=9999999999&since=' + encodeURIComponent(lastRead) : '?timeout=9999999999';
+        const suffix = lastRead ? '?timeout=40&since=' + encodeURIComponent(lastRead) : '?timeout=40';
         
         // Connect to Girder's notification stream endpoint for SSE
         console.log("Connecting...");

--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -1,0 +1,68 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import $ from 'jquery';
+import config from '../config/environment';
+
+// Load a polyfill for EventSource to allow passing custom headers (e.g. token)
+const EventSource = window.EventSourcePolyfill;
+
+export default Service.extend({
+    tokenHandler: service('token-handler'),
+    apiHost: config.apiHost,
+    source: null,
+    
+    /* Connect if not connected, otherwise return existing instance */
+    connect() {
+        const source = this.get('source');
+        if (source != null) {
+            this.close();
+            console.log("Reconnecting...");
+        } else {
+            console.log("Connecting...");
+        }
+        
+        
+        const token = this.get('tokenHandler').getWholeTaleAuthToken();
+        const endpoint = this.get('apiHost') + '/api/v1/notification/stream';
+        const newSource = new EventSource(endpoint, {
+          headers: {
+            'Girder-Token': token
+          }
+        });
+        
+        newSource.onopen = this.onOpen.bind(this);
+        newSource.onmessage = this.onMessage.bind(this);
+        newSource.onerror = this.onError.bind(this);
+        
+        this.set('source', newSource);
+        
+        return newSource;
+    },
+    
+    /* Close if possible, otherwise noop */
+    close() {
+        let source = this.get('source');
+        if (source) {
+            console.log('Closing connection...');
+            source.close();
+        }
+    },
+    
+    onOpen() {
+        console.log("Connection to server opened.")
+    },
+    onMessage(event) {
+        //console.log("Message recv'd:", event);
+        let events = this.get('events');
+        events.push(event);
+        this.set('events', events);
+        let json = JSON.parse(event.data)
+        console.log("JSON data recv'd:", json);
+        alert(event.data);
+    },
+    onError(error) {
+        console.log("EventSource failed.");
+        if (this.get('source').readyState == EventSource.CLOSED) return;
+        console.error(error);
+    },
+});

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -68,5 +68,6 @@ module.exports = function (defaults) {
   // modules that you would like to import into your application
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
+  app.import('node_modules/event-source-polyfill/src/eventsource.js');
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "torii": "^0.10.1"
   },
   "dependencies": {
+    "event-source-polyfill": "^1.0.5",
     "guid": "0.0.12",
     "lodash": "^4.17.10",
     "marked": "^0.3.19",


### PR DESCRIPTION
### Problem
Rebuild needs to notify user when build completes or fails. User needs to be able to view the logs from failed events to fix the broken build.

### Approach
Implement SSE using a custom `EventSource` allowing us to pass the `Girder-Token` header. Also added a log viewer modal that will display pre-formatted text

NOTE: There may still be formatting errors in the log output that we should revisit (e.g. random commas, escape sequences, console codes, etc)

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch a Tale, if you haven't already
4. Navigate to the "Run" view and select a Tale
5. Expand the "..." dropdown at the top-center, and choose "Rebuild Tale"
    * After a few seconds, you should see the new `notification-stream` component appear to tell you that the image is building
6. Click on the status (e.g. `BUILDING`) to see the logs
    * You should see that the log output is automatically updated/refreshed every ~2 seconds
    * Once the build is complete, you should receive another notification indicating that your build is successful (e.g. `SUCCESS`)
    * You should be offered on option to "Restart to Use New Image"
7. Modify the `apt.txt` in your workspace to contain a nonsense package name (e.g. `q; isdhadshiasd `)
8. Select "Rebuild Tale" again
    * After a few seconds, you should see the new `notification-stream` component appear to tell you that the image is building
    * After a few more seconds, you should see a new notification appear indicating that the image build failed (e.g. `INVALID`)
9. Click "Mark All as Read" atop the notification-stream
    * Your notification-stream should dismiss itself
    * Subsequent refreshes should **not** bring back dismissed notifications

NOTE: there is still a subtle timeout issue with EventSource's integration with Girder - see https://github.com/Yaffle/EventSource#server-side-requirements