### PR TITLE
Allow user to edit illustration field on a Tale

### DIFF
--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -62,7 +62,7 @@
     <div class="inline fields ui grid">
         <label class="two wide column right aligned">Illustration</label>
         <div class="ui action field thirteen wide column">
-            <input type="text" id="tale-icon" placeholder="Tale Icon" value={{model.tale.illustration}} readonly={{cannotEditTale}} />
+            {{input id=tale-icon value=model.tale.illustration placeholder="http://" readonly=cannotEditTale}}
             <div class="ui buttons">
                 <div class="or"></div>
                 <button class="ui positive blue button" {{action "generateIcon" model.tale}}>Generate Illustration</button>


### PR DESCRIPTION
### Problem
User cannot edit Illustration field on the new Tale Metadata tab in the Run view.

### Approach
Use a two-way binding instead of a one-way for this field.

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch a Tale, if you haven't already
4. Navigate to the Run view, select an instance on the right, and choose the Metadata tab
5. Scroll down to the end of the form and edit the `illustration` field - you can just change the url slightly if you want
6. Open your developer console to the Networks tab, and then click Save
    * You should see your PUT request come through with the new (correct) value for `illustration`
    * Compare with https://dashboard.dev.wholetale.org
7. Refresh the page
    * Your new URL value should be preserved across page loads/refreshes