### PR TITLE
Support Multiple Tale Authors

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -80,17 +80,6 @@ export default Component.extend(FullScreenMixin, {
                 iframeWindow.parent.postMessage('message sent', window.location.origin);
             };
         }
-        if(self.model) {
-          self.store.findRecord('tale', self.model.taleId)
-          .then(tale => {
-            if (tale.creatorId === self.userAuth.getCurrentUserID()) {
-              self.set('enablePublish', true);
-            }
-            else {
-              self.set('enablePublish', false);
-            }
-          });
-        }
     },
 
     didInsertElement() {      

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -7,7 +7,7 @@
                     <img class="env" src="{{model.tale.icon}}" />
                     <div class="header name">
                         <h3>{{truncate-name model.name}}</h3>
-                        <span>{{model.tale.authors}}</span>
+                        <span>{{tale-authors-to-str model.tale.authors}}</span>
                     </div>
                 </div>
                 <div class="right borderless menu">

--- a/app/components/ui/tale-browser/template.hbs
+++ b/app/components/ui/tale-browser/template.hbs
@@ -243,7 +243,7 @@
                                     </div>
                                 </td>
                                 <td>
-                                    <div style="color: #67c096; font-size: 75%">{{model.authors}}</div>
+                                    <div style="color: #67c096; font-size: 75%">{{tale-authors-to-str model.authors}}</div>
                                 </td>
                                 <td style="text-align: center;">
                                     {{#if (eq tale_instantiating_id model.id)}}
@@ -334,7 +334,7 @@
                             <div style="padding: 4px"></div>
                             <div style="color: #67c096">
                                 {{#if model.authors}}
-                                    {{model.authors}}
+                                    {{tale-authors-to-str model.authors}}
                                 {{else}}
                                     &nbsp;
                                 {{/if}}

--- a/app/components/ui/tale-tab-metadata/component.js
+++ b/app/components/ui/tale-tab-metadata/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
-
+import Object, { computed } from '@ember/object';
+import { A } from '@ember/array';
 import $ from 'jquery';
 
 import config from '../../../config/environment';
@@ -20,9 +20,15 @@ export default Component.extend({
   licenses: [],
   model: null,
   publishedURL: 'This Tale has not been published',
+  // Array of author dicts that the template uses to render rows
+  taleAuthors: A(),
+  // An error message that can get set, displayed in the error modal
+  errorMessage: String(),
+  model: null,
+  cannotEditTale: computed.not('canEditTale').readOnly(),
   init() {
     this._super(...arguments);
-    
+
     // Fetch images for user to select an environment
     const component = this;
     $.getJSON(this.get('apiHost') + '/api/v1/image/').then(function(images) {
@@ -42,7 +48,16 @@ export default Component.extend({
       this.set('publishedURL', tale.publishInfo[tale.publishInfo.length - 1].uri );
     }
   },
-  
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    // Re-render the rows by discarding the previous state and
+    // re-adding the authors
+    this.taleAuthors.clear();
+    this.addTaleAuthors();
+  },
+
   didRender() {
     // Enable the environment dropdown functionality
     $('.ui.dropdown').dropdown();
@@ -70,18 +85,110 @@ export default Component.extend({
   canEditTale: computed('model.tale._accessLevel', function () {
     return this.get('model') && this.get('model').get('tale') && this.get('model').get('tale').get('_accessLevel') >= taleStatus.WRITE;
   }).readOnly(),
-  cannotEditTale: computed.not('canEditTale').readOnly(),
+      
+   /* 
+    Generates a uui that can assigned to a tale author. Note that this change 
+    allows identification about which author row is being interacted with. This
+    change does not persist to the backend.
+   */
+  ID() {
+    let array = new Uint32Array(8)
+    window.crypto.getRandomValues(array)
+    let str = ''
+    for (let i = 0; i < array.length; i++) {
+      str += (i < 2 || i > 5 ? '' : '-') + array[i].toString(16).slice(-4)
+    }
+    return str
+  },
+
+  /* 
+    Adds the Tale's saved authors to the component property
+    that the handlebars template uses to create rows (this.taleAuthors)
+  */
+ addTaleAuthors() {
+  let authors = this.get('model').get('tale').authors;
   
+  for (let i = 0; i < authors.length; i++) {
+    let newAuthor = {
+      'id': this.ID(),
+      'firstName': authors[i].firstName,
+      'lastName': authors[i].lastName,
+      'orcid': authors[i].orcid
+  }
+    this.taleAuthors.pushObject(newAuthor);
+  }
+},
+
+  /* 
+    Iterates over the array of saved&unsaved authors and makes sure that
+      1. There is at least one author
+      2. All of the authors have a first & last name and and an ORCID
+  */
+  validateAuthors () {
+    if (this.taleAuthors.length < 1) {
+      this.set('errorMessage', 'Your Tale must have at least one author; please add one to the Tale.');
+      return false
+    }
+    let res = true;
+    this.taleAuthors.forEach((author) => {
+      if (author.lastName.length < 1) {
+        this.set('errorMessage', "There is a Tale author that's missing a last name.");
+        res = false
+      }
+      if (author.firstName.length < 1 ) {
+        this.set('errorMessage', "There is a Tale author that's missing a first name.");
+        res = false;
+      }
+      if (author.orcid.length < 1) {
+        this.set('errorMessage', "There is a Tale author that's missing an ORCID.");
+        res = false;
+      }
+    });
+    return res;
+  },
+  
+  /* 
+    There is a discrepency between the Tale 'authors' object and the ones used in the
+    component. The ID field needs to be removed before adding the structure to the model.
+    This method formats the component object and updates the Tale model with it.
+  */
+  addAuthorsTaleModel() {
+    let taleAuthors = []
+    this.taleAuthors.forEach((author) => {
+      taleAuthors.push(
+        {
+          'firstName': author.firstName,
+          'lastName': author.lastName,
+          'orcid': author.orcid
+        })
+      })
+    this.model.tale.set('authors', taleAuthors);
+  },
   actions: {
+
+    /* 
+      Takes the fields in the UI and updates the Tale model with the new
+      values.
+    */
     updateTale() {
       const tale = this.get('model').get('tale');
       const onFail = (e) => {
-        alert('Error saving tale (' + tale['id'] + '):', e);
+        this.set('errorMessage', ('Error saving tale (' + tale['id'] + '):', e));
+        this.send('openErrorModal');
       };
-      
-      tale.save().catch(onFail);
+
+      // Only update the Tale if the authors are valid
+      if (this.validateAuthors()) {
+        // Preform any author formatting
+        this.addAuthorsTaleModel()
+        // Request that the Tale model be updated
+        tale.save().catch(onFail);
+      }
+      else {
+        this.send('openErrorModal');
+      }
     },
-      
+
     setTaleEnvironment: function(selected) {
       const tale = this.get('model').get('tale');
       tale.set('imageId', selected);
@@ -90,6 +197,48 @@ export default Component.extend({
     setTaleLicense: function(selected) {
       const tale = this.get('model').get('tale');
       tale.set('licenseSPDX', selected);
+    },
+    
+    /* 
+    Adds a new, blank user to the component authors object, which
+    then gets added as a new row in the UI.
+    */
+    addNewAuthor() {
+      let newAuthor = {
+        'id': this.ID(),
+        'firstName': '',
+        'lastName': '',
+        'orcid':'',
+      }
+      this.taleAuthors.pushObject(newAuthor)
+    },
+
+    /* 
+    Removes an author from the component, and is consequentially removed
+    in the UI.
+    */
+    removeAuthor(id) {
+      let currentAuthors = this.get('taleAuthors');
+      let deletedAuthor = currentAuthors.find(o => o.id === id);
+      if(deletedAuthor){
+        let authorLocation = currentAuthors.indexOf(deletedAuthor);
+        if (authorLocation > -1) {
+          this.taleAuthors.removeAt(authorLocation);
+        }
+      }
+    },
+
+    /* 
+      Open the modal that the user sees when an error occurred or when validation failed.
+    */
+    openErrorModal() {
+      let selector = '.ui.metadata-error.modal';
+      $(selector).modal('setting', 'closable', true);
+      $(selector).modal('show');
+    },
+    
+    closeErrorModal() {
+      return false;
     },
   }
 });

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -9,7 +9,7 @@
     <div class="inline fields ui grid">
       <label class="two wide column right aligned">Authors</label>
     </div>
-    {{#each taleAuthors as |author|}}
+    {{#each taleAuthors as |author index|}}
     <div class="inline fields ui grid">
       <label class="two wide column right aligned"></label>
       <div class="field thirteen wide column" id=author.id>
@@ -17,17 +17,17 @@
           <div class="inline fields">
             <label>First Name:</label>
               <div class="field">
-                {{input type="text" name='first-name' value=author.firstName placeholder="Sur Name" }}
+                {{input type="text" name='first-name' value=author.firstName placeholder="First Name" readonly=cannotEditTale }}
               </div>
             <label>Last Name:</label>
             <div class="field">
-              {{input type="text" name='last-name' value=author.lastName placeholder="Family Name" }}
+              {{input type="text" name='last-name' value=author.lastName placeholder="Last Name" readonly=cannotEditTale }}
             </div>
           <label>ORCID:</label>
           <div class="field">
-            {{input type="url" name='orcid-id' placeholder="https://orcid.org/0000-0002-1825-0097"  value=author.orcid }}
+            {{input type="url" name='orcid-id' placeholder="https://orcid.org/0000-0002-1825-0097"  value=author.orcid readonly=cannotEditTale }}
           </div>
-          <i class="fa fa-window-close" aria-hidden="true" style="color: black" {{action 'removeAuthor' author.id}}></i>
+          <i class="fa fa-window-close" aria-hidden="true" {{action 'removeAuthor' index}}></i>
         </div>
       </div>
     </div>
@@ -36,9 +36,9 @@
       
     <div class="inline fields ui grid">
         <label class="two wide column right aligned"></label>
-        <div class="field thirteen wide column">
-            <label></label> <i class="fas fa-plus" style="color: #2185d0; margin-left: 10%;"{{action 'addNewAuthor'}}></i>
-            <span style="color: #2185d0;" {{action 'addNewAuthor'}}>&nbsp;Add another author</span>
+        <div class="field thirteen wide column add-author">
+            <i class="fas fa-plus add-author-icon" {{action 'addNewAuthor'}}></i>
+            <span {{action 'addNewAuthor'}}>&nbsp;Add another author</span>
         </div>
     </div>
 
@@ -137,18 +137,17 @@
     </div>
 </div>
 
-
-<div class="ui metadata-error modal" style="display: none">
+<div class="ui metadata-error modal">
     <div class="header">
         Error While Saving Tale
     </div>
     <div class="image content">
         <div class="description">
-            <p style="text-align: center">{{errorMessage}}</p>
+            <p>{{errorMessage}}</p>
         </div>
     </div>
     <div class="actions">
-        <div class="ui black deny button" {{action 'closeErrorModal'}}>
+        <div class="ui black deny button">
             Close
         </div>
     </div>

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -7,9 +7,37 @@
     </div>
 
     <div class="inline fields ui grid">
-        <label class="two wide column right aligned">Authors</label>
+      <label class="two wide column right aligned">Authors</label>
+    </div>
+    {{#each taleAuthors as |author|}}
+    <div class="inline fields ui grid">
+      <label class="two wide column right aligned"></label>
+      <div class="field thirteen wide column" id=author.id>
+        <div class="ui form">
+          <div class="inline fields">
+            <label>First Name:</label>
+              <div class="field">
+                {{input type="text" name='first-name' value=author.firstName placeholder="Sur Name" }}
+              </div>
+            <label>Last Name:</label>
+            <div class="field">
+              {{input type="text" name='last-name' value=author.lastName placeholder="Family Name" }}
+            </div>
+          <label>ORCID:</label>
+          <div class="field">
+            {{input type="url" name='orcid-id' placeholder="https://orcid.org/0000-0002-1825-0097"  value=author.orcid }}
+          </div>
+          <i class="fa fa-window-close" aria-hidden="true" style="color: black" {{action 'removeAuthor' author.id}}></i>
+        </div>
+      </div>
+    </div>
+  </div>
+  {{/each}}
+      
+    <div class="inline fields ui grid">
+        <label class="two wide column right aligned"></label>
         <div class="field thirteen wide column">
-            {{input value=model.tale.authors readonly=cannotEditTale}}
+            <label></label> <i class="fas fa-plus" style="color: rgb(44,119,143); margin-left: 10%;"{{action 'addNewAuthor'}}>  Add another author</i>
         </div>
     </div>
 
@@ -104,6 +132,23 @@
         </div>
         <div class="field toggle ui checkbox four wide column">
             {{ui-checkbox class="toggle" label="Public?" checked=model.public onChange=(action (mut model.tale.public)) disabled=cannotEditTale}}
+        </div>
+    </div>
+</div>
+
+
+<div class="ui metadata-error modal" style="display: none">
+    <div class="header">
+        Error While Saving Tale
+    </div>
+    <div class="image content">
+        <div class="description">
+            <p style="text-align: center">{{errorMessage}}</p>
+        </div>
+    </div>
+    <div class="actions">
+        <div class="ui black deny button" {{action 'closeErrorModal'}}>
+            Close
         </div>
     </div>
 </div>

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -37,7 +37,8 @@
     <div class="inline fields ui grid">
         <label class="two wide column right aligned"></label>
         <div class="field thirteen wide column">
-            <label></label> <i class="fas fa-plus" style="color: rgb(44,119,143); margin-left: 10%;"{{action 'addNewAuthor'}}>  Add another author</i>
+            <label></label> <i class="fas fa-plus" style="color: #2185d0; margin-left: 10%;"{{action 'addNewAuthor'}}></i>
+            <span style="color: #2185d0;" {{action 'addNewAuthor'}}>&nbsp;Add another author</span>
         </div>
     </div>
 

--- a/app/helpers/tale-authors-to-str.js
+++ b/app/helpers/tale-authors-to-str.js
@@ -1,0 +1,35 @@
+import { helper } from '@ember/component/helper';
+
+    /**
+    * Takes a list of authors from the backend and returns a string of first
+    * and last names that can be shown in the UI.
+    * 
+    * The names are added to a string that should look like
+    * Craig Willis, Root VonKlomph, Mike Lambert
+    * 
+    * Note that the last user doesn't have a comma at the end, and that if
+    * the Tale only has a single author, there shouldn't be a comma. This can
+    * be achieved by checking the size of the tale['authors'] array and keeping
+    * track of the current position.
+    * 
+    * @method taleAuthorsToStr
+    * @param params A list of JSON Tale authors [{author1}, {author2}, etc]
+    */
+export function taleAuthorsToStr(params/*, hash*/) {
+  // String that will be shown to the UI.
+  let allAuthors = String();
+  params = params[0]
+  if(params) {
+    for(let position=0; position<params.length; position++) {
+      let author = params[position];
+      if (position>=1 && position<params.length) {
+        // If there are more than one authors and we aren't at the last one
+        allAuthors += ', '
+      }
+    allAuthors += author.firstName + ' ' + author.lastName;
+    }
+  }
+  return allAuthors;
+}
+
+export default helper(taleAuthorsToStr);

--- a/app/models/tale.js
+++ b/app/models/tale.js
@@ -4,7 +4,7 @@ export default DS.Model.extend({
   "_accessLevel": DS.attr('number'),
   "_id": DS.attr('string'),
   "_modelType": DS.attr('string'),
-  "authors":  DS.attr('string'),
+  "authors":  DS.attr(),
   "category":  DS.attr('string'),
   "config": DS.attr(),
   "created": DS.attr('date'),

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -13,6 +13,7 @@
 @import './manage-page';
 @import './tale-tab-interact';
 @import './tale-tab-files';
+@import './tale-tab-metadata.scss';
 
 html,
 body {

--- a/app/styles/tale-tab-metadata.scss
+++ b/app/styles/tale-tab-metadata.scss
@@ -1,0 +1,11 @@
+.add-author {
+  color: #2185d0;
+}
+
+.add-author-icon {
+  margin-left: 10%;
+}
+
+.metadata-error.modal .description {
+  text-align: center;
+}

--- a/app/templates/tale/view.hbs
+++ b/app/templates/tale/view.hbs
@@ -75,7 +75,7 @@
                                 <div class="eight wide column">
                                     <div class="ui huge header" style="margin: 0 0 5px 0"> {{model.title}} </div>
                                     <div class="ui header" style="margin: 0 0 5px 0">
-                                        By <span style="color: #67c096">{{model.authors}} </span>
+                                        By <span style="color: #67c096">{{tale-authors-to-str model.authors}} </span>
                                     </div>
                                 </div>
                                 <div class="eight wide right aligned column">


### PR DESCRIPTION
### Displaying Names in the Dashboard
We could historically just display `model.authors` however, we need to parse the structure returned by the backend to concatenate the multiple authors.

#### Scope
We display the authors on the Tale view, the run page, and on the browse page. Changes will be made at on the templates at those locations.

#### Testing

1. Check out this branch
2. Check out the `tale_author_refactor ` branch in girder_wholetale
3. Launch the dashboard
4. Confirm the display of current Tale authors is fine
5. Add authors to your Tale (by the girder api or via the (not yet complete) second piece of this commit
6. Confirm that the authors string is correct (no comma on a single author, comma on multiple authors)

### Adding, Removing, & Editing Tale Authors
<img width="1121" alt="Screen Shot 2019-03-24 at 6 58 51 PM" src="https://user-images.githubusercontent.com/9289652/54890510-ec52f080-4e66-11e9-827d-fa50156a6090.png">

This feature allows users to document additional Tale authors. The user can click the  `Add another author` text or icon to add another row and the black `x` box to delete one.


Each author that is shown in the list can be mapped to an object in  [taleAuthors](https://github.com/whole-tale/dashboard/pull/445/files#diff-e60b019ad701f87474adc04c538b0ed6R21).

For example, `taleAuthors` may initially look like
```
{
        'id': "uuid:1234567",
        'firstName': ''John",
        'lastName': '' Doe",
        'orcid':''",
}
```
Since the UI [iterates over this](https://github.com/whole-tale/dashboard/pull/445/files#diff-2ff527d24dedca82b5013f5680c14742R12), the user will see a single author with the attributes described above.

When a user clicks to add a new author, a new author with blank (except id) attributes is created and pushed into `taleAuthors`. This triggers the template to refresh and add a new row with blank attributes. When a user clicks the delete icon, the author' `id` [is sent to an action](https://github.com/whole-tale/dashboard/pull/445/files#diff-2ff527d24dedca82b5013f5680c14742R30) which then finds the author in `taleAuthors` and removes it.

When the user clicks save, the [validation](https://github.com/whole-tale/dashboard/pull/445/files#diff-e60b019ad701f87474adc04c538b0ed6R101) is performed. I was having issues turning the borders of the problematic entries so I [added an error dialog](https://github.com/whole-tale/dashboard/pull/445/files#diff-2ff527d24dedca82b5013f5680c14742R113).


#### Testing

1. Check out this branch
2. Check out the `tale_author_refactor ` branch in girder_wholetale
3. Launch the dashboard
4. Navigate to run>metadata
5. Play around with adding and removing authors, and verifying the changes were made in the backend via the API
6. Note that you aren't able to save a Tale without authors
7. Note that you aren't able to save unless all authors have names and an ORCID