### PR TITLE
Ensure deleted instance is removed from 'Tale Instances' on the Run view

### DIFF
--- a/app/components/ui/tale-instances/template.hbs
+++ b/app/components/ui/tale-instances/template.hbs
@@ -19,31 +19,40 @@
         </div>
     {{/if}}
     <div class="tales-list">
-        {{#each models as |instance index|}}
-            <div class="ui vertical menu fluid tales">
-                <a class="item {{if (and internalState.currentInstanceId (eq internalState.currentInstanceId instance._id)) 'active'}}" {{action 'transitionToRun' instance index preventDefault=true}}>
-                        <img src="{{instance.tale.illustration}}" />
-                        <img src="{{instance.tale.icon}}" class="env" />
-                        {{#unless (eq instance.status 0)}}
-                            <i class="times icon" {{action 'openDeleteModal' instance bubbles=false}}></i>
-                        {{/unless}}
-                        <p>{{truncate-name instance.name}}</p>
-                    {{#if (eq instance.status 0)}}
-                        <span style="position: absolute; left: 45%; top: 20%; opacity: .7; z-index: 1">
-                            <i class="fa fa-4x fa-circle-notch fa-spin" aria-hidden="true"></i>
-                        </span>
-                    {{/if}}
-                </a>
+        {{#if deletingInstance}}
+            <div id="instance-deleting-loader" class="ui segment">
+              <p></p>
+              <div class="ui active inverted dimmer">
+                <div class="ui huge loader"></div>
+              </div>
             </div>
         {{else}}
-            <div class="ui vertical menu fluid tales">
-                <div class="ui grid">
-                    <div class="center aligned sixteen wide column">
-                        <div style="padding: 45% 0;font-style:italic;">No tales have been launched</div>
+            {{#each models as |instance index|}}
+                <div class="ui vertical menu fluid tales">
+                    <a class="item {{if (and internalState.currentInstanceId (eq internalState.currentInstanceId instance._id)) 'active'}}" {{action 'transitionToRun' instance index preventDefault=true}}>
+                            <img src="{{instance.tale.illustration}}" />
+                            <img src="{{instance.tale.icon}}" class="env" />
+                            {{#unless (eq instance.status 0)}}
+                                <i class="times icon" {{action 'openDeleteModal' instance bubbles=false}}></i>
+                            {{/unless}}
+                            <p>{{truncate-name instance.name}}</p>
+                        {{#if (eq instance.status 0)}}
+                            <span style="position: absolute; left: 45%; top: 20%; opacity: .7; z-index: 1">
+                                <i class="fa fa-4x fa-circle-notch fa-spin" aria-hidden="true"></i>
+                            </span>
+                        {{/if}}
+                    </a>
+                </div>
+            {{else}}
+                <div class="ui vertical menu fluid tales">
+                    <div class="ui grid">
+                        <div class="center aligned sixteen wide column">
+                            <div style="padding: 45% 0;font-style:italic;">No tales have been launched</div>
+                        </div>
                     </div>
                 </div>
-            </div>
-        {{/each}}
+            {{/each}}
+        {{/if}}
     </div>
 </div>
 

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -1240,3 +1240,13 @@ wt.panel .wt.paddleboard.header i {
   }
 }
 
+#instance-deleting-loader {
+  border: none;
+  height: 100%;
+  height: -moz-available;
+  height: -fill-available;
+  height: fill-available;
+  height: stretch;
+  height: -webkit-fill-available;
+  height: -o-fill-available;
+}


### PR DESCRIPTION
### Problem
When deleting a Tale Instance from the right side panel in the Run view, sometimes the instance will reappear instantly. This is due to our own logic that would redirect the user back to `run.index` from `run.view` when an instance was deleted. This would cause Ember to requerying for the instances before Girder finished deleting them.

### Approach
Adding a timeout/loading indicator when redirecting back to run after deleting the selected instance

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch one or more Tale, if you haven't already
4. Wait for the Tale to launch, then navigate to the Run view
5. On the right side, click the X button at the top-right of the instance to delete it
    * You should be prompted for confirmation
6. Confirm deletion
    * You should see a loading indicator pop up for ~2 seconds
    * After 2 seconds, you should be redirected to the `run.index` view (no tale instance selected)
    * After 2 seconds, you should see the Tale Instances panel contents reappear and your deleted should no longer be present
6. Test deleting Tales under different conditions to ensure that no strange edge cases exist:
    * Delete instance from browse view
    * Delete instance from run view with nothing selected
    * Delete instance from the run view while a different instance selected
    * Delete the currently-selected instance from the run view
    * NOTE: this does not fix deleting a tale from the `tale.view` - the workaround for that logic would be similar, but is not shared with the files changed here