### PR TITLE
Do not fetch records inside didRender(). Fixes #454

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -80,17 +80,6 @@ export default Component.extend(FullScreenMixin, {
                 iframeWindow.parent.postMessage('message sent', window.location.origin);
             };
         }
-        if(self.model) {
-          self.store.findRecord('tale', self.model.taleId)
-          .then(tale => {
-            if (tale.creatorId === self.userAuth.getCurrentUserID()) {
-              self.set('enablePublish', true);
-            }
-            else {
-              self.set('enablePublish', false);
-            }
-          });
-        }
     },
 
     didInsertElement() {      


### PR DESCRIPTION
I cherry-picked the relevant commit from https://github.com/whole-tale/dashboard/pull/445 and adjusted the commit message.

### How to test?
1. Launch a Tale
2. Navigate to Run view
3. Using dev console (or watching the girder logs) confirm that Dashboard doesn't hammer the backend with 15 requests per second.