### PR TITLE
Add Tale's Cited Datasets to Metadata View

### DIFF
--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -68,6 +68,20 @@
     </div>
 
     <div class="inline fields ui grid">
+      <label class="two wide column right aligned">Datasets used</label>
+    </div>
+    {{#each model.tale.dataSetCitation as |citation|}}
+    <div class="inline fields ui grid">
+      <label class="two wide column right aligned"></label>
+      <div class="field thirteen wide column">
+        <div class="ui form">
+          {{citation}}
+        </div>
+      </div>
+    </div>
+    {{/each}}
+
+    <div class="inline fields ui grid">
         <label class="two wide column right aligned">License</label>
         <div class="field thirteen wide column">
             <div id="licenseDropdown" class="ui icon selection dropdown license {{if (eq licenses.length 0) "loading"}}">

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -78,6 +78,8 @@
             {{citation}}
           </div>
         </div>
+        {{else}}
+          No citable data
       {{/each}}
     </div>
     

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -69,18 +69,18 @@
 
     <div class="inline fields ui grid">
       <label class="two wide column right aligned">Datasets used</label>
-    </div>
-    {{#each model.tale.dataSetCitation as |citation|}}
-    <div class="inline fields ui grid">
-      <label class="two wide column right aligned"></label>
-      <div class="field thirteen wide column">
-        <div class="ui form">
-          {{citation}}
+      {{#each model.tale.dataSetCitation as |citation index|}}
+        {{#if index}}
+          <label class="two wide column right aligned"></label>
+        {{/if}}
+        <div class="field thirteen wide column" style="margin-bottom:10px;">
+          <div class="ui form">
+            {{citation}}
+          </div>
         </div>
-      </div>
+      {{/each}}
     </div>
-    {{/each}}
-
+    
     <div class="inline fields ui grid">
         <label class="two wide column right aligned">License</label>
         <div class="field thirteen wide column">

--- a/app/models/tale.js
+++ b/app/models/tale.js
@@ -18,6 +18,7 @@ export default DS.Model.extend({
   "title": DS.attr('string'),
   "updated": DS.attr('date'),
   "dataSet": DS.attr(),
+  "dataSetCitation": DS.attr(),
   "folderId": DS.attr('string'),
   "licenseSPDX": DS.attr('string')
 });


### PR DESCRIPTION
This PR adds citations of the used datasets to the dashboard. The attached issue is #450 

Note that the `291_dataset_citations` branch in girder_wholetale should be merged before this.

### To Test:
1. Check this branch out
2. Check out the [291_dataset_citations](https://github.com/whole-tale/girder_wholetale/tree/291_dataset_citations) branch in girder_wholetale
3. Create a Tale
4. Add n datasets
5. Navigate to the `Metadata` tab
6. See citations listed

<img width="1125" alt="Screen Shot 2019-04-08 at 11 46 33 AM" src="https://user-images.githubusercontent.com/9289652/55748630-ff7fc780-59f3-11e9-8fb0-46a927bbe701.png">
