### PR TITLE
Improve notification-stream UX

### DIFF
--- a/app/components/dashboard/unified-view/template.hbs
+++ b/app/components/dashboard/unified-view/template.hbs
@@ -8,5 +8,3 @@
     </div>
   </div>
 </div>
-
-{{ui/notification-stream}}

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -106,6 +106,10 @@ export default Component.extend({
             self.set('selectedEventLogs', []);
             $('#log-viewer-modal').modal('hide');
         },
+        
+        gotoTale(taleId) {
+           this.router.transitionTo('run.view', taleId); 
+        },
     }
 });
  

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -2,21 +2,21 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
-import EmberObject from '@ember/object';
+import EmberObject, { computed } from '@ember/object';
 import config from '../../../config/environment';
 import $ from 'jquery';
 import layout from './template';
 
 export default Component.extend({
     layout,
-    notificationStream: service('notification-stream'),
     
+    notificationStream: service('notification-stream'),
     apiCall: service('api-call'),
     store: service(),
-    logInterval: null,
-    isDev: config.dev,
     
-    events: A([]),
+    logInterval: null,
+    DEBUG: config.dev,
+    
     source: null,
     selectedEvent: null,
     selectedEventLogs: [],
@@ -25,15 +25,7 @@ export default Component.extend({
         const self = this;
         const source = self.get('notificationStream').connect();
         
-        source.onopen = () => console.log("Connected to event server.");
-        source.onmessage = self.onMessage.bind(this);
-        source.onerror = (err) => {
-            console.log("EventSource failed:", err);
-            this.get('notificationStream').close();
-        };
-        
         self.set('source', source);
-        self.set('events', A([]));
     },
     
     willDestroyElement() {
@@ -43,28 +35,7 @@ export default Component.extend({
             source.close();
         }
         
-        self.set('events', A([]));
         self.set('source', null);
-    },
-    
-    onMessage(event) {
-        const self = this;
-        // Parse event data (tale) into JSON
-        event.json = JSON.parse(event.data);
-        event.created = new Date(event.json.time).toLocaleString();
-        //console.log("Message recv'd:", event);
-        
-        // Push new event data
-        let events = self.get('events');
-        if (event.json.type == 'wt_image_build_status') {
-            events.unshiftObject(event);
-            self.set('events', events);
-            //console.log("New event:", events);
-        } else if (event.json.type == 'wt_error_backend_generic') {
-            console.log("Generic backend encountered:", event);
-        } else {
-            console.log("Ignored event type encountered:", event);
-        }
     },
         
     fetchLogs() {
@@ -91,17 +62,18 @@ export default Component.extend({
         markAllAsRead() {
             const self = this;
             self.get('notificationStream').markAllAsRead();
-            self.set('events', A([]));
         },
         
         restartTaleInstance(tale) {
             const self = this;
-            const adapterOptions = { queryParams: { limit: "0" } };
-            self.get('store').query('instance', { reload: false, backgroundReload: false, adapterOptions }).then(instances => {
+            const adapterOptions = { queryParams: { limit: "0", taleId: tale._id } };
+            self.get('store').query('instance', { 
+                reload: false, 
+                backgroundReload: false, 
+                adapterOptions 
+            }).then(instances => {
                 instances.forEach(instance => {
-                    if (tale._id == instance.taleId) {
-                        self.get('apiCall').restartInstance(instance);
-                    }
+                    self.get('apiCall').restartInstance(instance);
                 });
             });
         },

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -29,7 +29,7 @@
               <div class="summary">
                 {{!-- TODO: Link to "/run/:tale_id" view once that is finished --}}
                 {{!-- {{event.json.data._id}} --}}
-                <a class="user">
+                <a class="user" {{action 'gotoTale' event.json.data._id}}>
                   {{truncate-name event.json.data.title}}
                 </a>
                 <br>

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -1,147 +1,133 @@
-{{#with events}}
-  <style>
-      /* TODO: Move these to .css once finalized */
-      #event-notification-stream {
-          position: fixed;
-          z-index: 1;
-          top: 32px;
-          left: 70vw;
-          width: 26vw;
-          background: #fff;
-          box-shadow: 0 0 4px rgba(0,0,0,.2);
-          border: 1px solid rgba(0,0,0,.2);
-          border-radius: 1rem;
-          padding-bottom: 15px;
-          max-height: 40vh;
-          overflow-y: auto;
-      }
-      #ack-all-button {
-          border-radius: 1rem 1rem 0 0;
-      }
-      .event-icon{
-          margin: 15px 12px;
-      }
-  </style>
+{{#if notificationStream.showNotificationStream}}
   <div class="ui feed computer tablet only" id="event-notification-stream">
       
-    <button class="ui button fluid" id="ack-all-button" {{action 'markAllAsRead'}}>Mark All as Read</button>
+    <button class="ui button fluid" id="ack-all-events-button" {{action 'markAllAsRead'}}>Mark All as Read</button>
     
-    {{#each events as |event index|}}
-      {{!-- Ignore everything but build events --}}
-      {{#if (eq event.json.type 'wt_image_build_status')}}
-        {{#if (gt index 0)}}<hr />{{/if}}
-        <div class="event">
-          <div class="label">
-            {{#if (eq event.json.data.imageInfo.status 0)}}
-              <i class="fas fa-2x fa-fw fa-warning event-icon"></i>
-            {{else if (eq event.json.data.imageInfo.status 1)}}
-              <i class="fas fa-2x fa-fw fa-times event-icon"></i>
-            {{else if (eq event.json.data.imageInfo.status 2)}}
-              <i class="fas fa-2x fa-fw fa-cog fa-spin event-icon"></i>
-            {{else if (eq event.json.data.imageInfo.status 3)}}
-              <i class="fas fa-2x fa-fw fa-check event-icon"></i>
-            {{/if}}
-          </div>
-          <div class="content">
-            <div class="summary">
-              {{!-- TODO: Link to "/run/:tale_id" view once that is finished --}}
-              {{!-- {{event.json.data._id}} --}}
-              <a class="user">
-                {{truncate-name event.json.data.title}}
-              </a>
-              <br>
-              <div>
-                {{#if (eq event.json.data.imageInfo.status 0)}}
-                  Tale image is invalid.
-                {{else if (eq event.json.data.imageInfo.status 1)}}
-                  Tale image is unavailable.
-                {{else if (eq event.json.data.imageInfo.status 2)}}
-                  Building tale image...
-                {{else if (eq event.json.data.imageInfo.status 3)}}
-                  Tale image built successfully!
-                {{/if}}
-              </div>
-              <div class="date">
-                {{event.created}}
-              </div>
-            </div>
-            <div class="ui grid">
-              <div class="six wide column">
-                <div class="meta">
-                  <a class="status" {{action 'openLogViewerModal' event}}>
-                    View Logs
-                  </a>
-                </div>
-              </div>
-              <div class="ten wide column">
-                <div class="meta">
-                  {{#if (eq event.json.data.imageInfo.status 3)}}
-                    <a class="logs" {{action 'restartTaleInstance' event.json.data}}>
-                      Restart to Use New Image
-                    </a>
-                  {{/if}}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      {{else if (eq event.json.type 'wt_error_backend_generic')}}
-        <div class="event">
-          <div class="label">
-            <i class="fas fa-2x fa-fw fa-ban event-icon"></i>
-          </div>
-          <div class="content">
-            <div class="summary">
-              <a class="ui red label">ERROR</a> An error was encountered.
-              <div class="date">
-                {{event.created}}
-              </div>
-              <div class="meta">
-                {{#if isDev}}
-                  {{#if event.json.data.message}}
-                    {{event.json.data.message}}
-                  {{else}}
-                    {{event.json.data}}
-                  {{/if}}
-                {{else}}
-                   Please report this error to an administrator.
-                   {{#if event.json.data.code}}
-                     Error code: {{event.json.data.code}}
-                   {{/if}}
-                {{/if}}
-              </div>
-            </div>
-          </div>
-        </div>
-      {{/if}}
-    {{/each}}
-  </div>
-{{/with}}
-
-<div id="log-viewer-modal" class="ui modal">
-  <div class="ui icon header">
-    <i class="fas icon
-    {{if (eq selectedEvent.status 0) 'fa-pause-circle'}}
-    {{if (eq selectedEvent.status 1) 'fa-hourglass-half fa-pulse'}}
-    {{if (eq selectedEvent.status 2) 'fa-cog fa-spin'}}
-    {{if (eq selectedEvent.status 3) 'fa-check'}}
-    {{if (eq selectedEvent.status 4) 'fa-ban'}}
-    {{if (eq selectedEvent.status 5) 'fa-times'}}"></i>
-    Log Viewer
-  </div>
-  <div class="scrolling content">
-    {{#if selectedEventLogs}}
-      <pre>{{selectedEventLogs}}</pre>
-    {{else}}
-      <div class="ui segment" style="min-height:20vh">
-        <div class="ui active inverted dimmer">
-          <div class="ui text loader">Loading</div>
-        </div>
-        <p></p>
+    {{#if (eq notificationStream.events.length 0)}}
+      <div id="event-notification-placeholder" class="placeholder message">
+        <i class="huge check circle icon"></i>
+        <p>No new events</p>
       </div>
+    {{else}}
+      {{#each notificationStream.events as |event index|}}
+        {{!-- Ignore everything but build events --}}
+        {{#if (eq event.json.type 'wt_image_build_status')}}
+          {{#if (gt index 0)}}<hr />{{/if}}
+          <div class="event">
+            <div class="label">
+              {{#if (eq event.json.data.imageInfo.status 0)}}
+                <i class="event-icon huge warning icon"></i>
+              {{else if (eq event.json.data.imageInfo.status 1)}}
+                <i class="event-icon huge ban icon"></i>
+              {{else if (eq event.json.data.imageInfo.status 2)}}
+                <i class="event-icon huge cog loading icon"></i>
+              {{else if (eq event.json.data.imageInfo.status 3)}}
+                <i class="event-icon huge check icon"></i>
+              {{/if}}
+            </div>
+            <div class="content">
+              <div class="summary">
+                {{!-- TODO: Link to "/run/:tale_id" view once that is finished --}}
+                {{!-- {{event.json.data._id}} --}}
+                <a class="user">
+                  {{truncate-name event.json.data.title}}
+                </a>
+                <br>
+                <div>
+                  {{#if (eq event.json.data.imageInfo.status 0)}}
+                    Tale image is invalid.
+                  {{else if (eq event.json.data.imageInfo.status 1)}}
+                    Tale image is unavailable.
+                  {{else if (eq event.json.data.imageInfo.status 2)}}
+                    Building tale image...
+                  {{else if (eq event.json.data.imageInfo.status 3)}}
+                    Tale image built successfully!
+                  {{/if}}
+                </div>
+                <div class="date">
+                  {{event.created}}
+                </div>
+              </div>
+              <div class="ui grid">
+                <div class="six wide column">
+                  <div class="meta">
+                    <a class="status" {{action 'openLogViewerModal' event}}>
+                      View Logs
+                    </a>
+                  </div>
+                </div>
+                <div class="ten wide column">
+                  <div class="meta">
+                    {{#if (eq event.json.data.imageInfo.status 3)}}
+                      <a class="logs" {{action 'restartTaleInstance' event.json.data}}>
+                        Restart to Use New Image
+                      </a>
+                    {{/if}}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        {{else if (eq event.json.type 'wt_error_backend_generic')}}
+        
+        {{!-- NOTE: This is currently unused --}}
+          <div class="event">
+            <div class="label">
+              <i class="fas fa-2x fa-fw fa-ban event-icon"></i>
+            </div>
+            <div class="content">
+              <div class="summary">
+                <a class="ui red label">ERROR</a> An error was encountered.
+                <div class="date">
+                  {{event.created}}
+                </div>
+                <div class="meta">
+                  {{#if DEBUG}}
+                    {{#if event.json.data.message}}
+                      {{event.json.data.message}}
+                    {{else}}
+                      {{event.json.data}}
+                    {{/if}}
+                  {{else}}
+                     Please report this error to an administrator.
+                     {{#if event.json.data.code}}
+                       Error code: {{event.json.data.code}}
+                     {{/if}}
+                  {{/if}}
+                </div>
+              </div>
+            </div>
+          </div>
+        {{/if}}
+      {{/each}}
     {{/if}}
   </div>
-  <div class="actions">
-    <div class="ui button" {{action 'closeLogViewerModal'}}>Done</div>
+    
+  <div id="log-viewer-modal" class="ui modal">
+    <div class="ui icon header">
+      <i class="fas icon
+      {{if (eq selectedEvent.status 0) 'fa-pause-circle'}}
+      {{if (eq selectedEvent.status 1) 'fa-hourglass-half fa-pulse'}}
+      {{if (eq selectedEvent.status 2) 'fa-cog fa-spin'}}
+      {{if (eq selectedEvent.status 3) 'fa-check'}}
+      {{if (eq selectedEvent.status 4) 'fa-ban'}}
+      {{if (eq selectedEvent.status 5) 'fa-times'}}"></i>
+      Log Viewer
+    </div>
+    <div class="scrolling content">
+      {{#if selectedEventLogs}}
+        <pre>{{selectedEventLogs}}</pre>
+      {{else}}
+        <div class="ui segment" style="min-height:20vh">
+          <div class="ui active inverted dimmer">
+            <div class="ui text loader">Loading</div>
+          </div>
+          <p></p>
+        </div>
+      {{/if}}
+    </div>
+    <div class="actions">
+      <div class="ui button" {{action 'closeLogViewerModal'}}>Done</div>
+    </div>
   </div>
-</div>
+{{/if}}

--- a/app/components/ui/tale-instances/template.hbs
+++ b/app/components/ui/tale-instances/template.hbs
@@ -29,18 +29,25 @@
         {{else}}
             {{#each models as |instance index|}}
                 <div class="ui vertical menu fluid tales">
-                    <a class="item {{if (and internalState.currentInstanceId (eq internalState.currentInstanceId instance._id)) 'active'}}" {{action 'transitionToRun' instance index preventDefault=true}}>
-                            <img src="{{instance.tale.illustration}}" />
-                            <img src="{{instance.tale.icon}}" class="env" />
-                            {{#unless (eq instance.status 0)}}
-                                <i class="times icon" {{action 'openDeleteModal' instance bubbles=false}}></i>
-                            {{/unless}}
-                            <p>{{truncate-name instance.name}}</p>
-                        {{#if (eq instance.status 0)}}
-                            <span style="position: absolute; left: 45%; top: 20%; opacity: .7; z-index: 1">
-                                <i class="fa fa-4x fa-circle-notch fa-spin" aria-hidden="true"></i>
-                            </span>
-                        {{/if}}
+                    <a class="item tale-instances-item {{if (and internalState.currentInstanceId (eq internalState.currentInstanceId instance._id)) 'active'}}" {{action 'transitionToRun' instance index preventDefault=true}}>
+                        <div class="ui grid">
+                            <div class="three wide column">
+                                {{#if (eq instance.status 0)}}
+                                    <i class="fa fa-4x fa-circle-notch fa-spin" aria-hidden="true"></i>
+                                {{else}}
+                                    <img src="{{instance.tale.illustration}}" />
+                                    <img src="{{instance.tale.icon}}" class="env" />
+                                {{/if}}
+                            </div>
+                            <div class="twelve wide column">
+                                <p>{{truncate-name instance.name}}</p>
+                            </div>
+                            <div class="one wide column">
+                                {{#unless (eq instance.status 0)}}
+                                    <i class="times icon" {{action 'openDeleteModal' instance bubbles=false}}></i>
+                                {{/unless}}
+                            </div>
+                        </div>
                     </a>
                 </div>
             {{else}}

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -12,6 +12,7 @@ export default Controller.extend({
   userAuth: service('user-auth'),
   internalState: service('internal-state'),
   notificationHandler: service('notification-handler'),
+  notificationStream: service('notification-stream'),
   tokenHandler: service(),
 
   user: computed(function() {
@@ -122,7 +123,11 @@ export default Controller.extend({
     toggleMobileMenu() {
       let displayMobileMenu = !this.get('mobileMenuDisplay');
       this.set('mobileMenuDisplay', displayMobileMenu);
-    }
+    },
+    toggleShowNotifications() {
+      this.notificationStream.set('showNotificationStream', 
+        !this.notificationStream.showNotificationStream); 
+    },
   }
 
 });

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -37,6 +37,6 @@ export default Controller.extend({
       let modal = $('.ui.harvester.modal');
       modal.parent().prependTo($(document.body));
       modal.modal('show');
-    }
+    },
   }
 });

--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -1,20 +1,27 @@
 import Service from '@ember/service';
+import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
 import config from '../config/environment';
+
+const DEBUG = config.dev;
+const VERBOSE = false;
 
 export default Service.extend({
     apiHost: config.apiHost,
     tokenHandler: service('token-handler'),
     timeout: 3600,
     source: null,
+    events: A([]),
     
-    /* Connect if not connected, otherwise return existing instance */
+    showNotificationStream: false,
+    
+    /* Connect if not connected, otherwise return existing connection */
     connect() {
         const self = this;
         const source = self.get('source');
         if (source != null) {
-            console.log("Reconnecting...");
+            DEBUG && VERBOSE && console.log("Reconnecting...");
             this.close();
         }
         
@@ -26,21 +33,34 @@ export default Service.extend({
         const querystring = `?${tokenQSP}&${timeoutQSP}&${sinceQSP}`;
         
         // Connect to Girder's notification stream endpoint for SSE
-        console.log("Connecting...");
+        DEBUG && VERBOSE && console.log("Connecting...");
         const endpoint = self.get('apiHost') + '/api/v1/notification/stream' + querystring;
         const newSource = new EventSource(endpoint);
+        
+        newSource.onopen = () => DEBUG && console.log("Connected to event server.");
+        newSource.onmessage = self.onMessage.bind(self);
+        newSource.onerror = (err) => {
+            (console && console.error && console.error("EventSource failed:", err))
+                || console.log("EventSource failed:", err);
+            self.get('notificationStream').close();
+        };  
         
         self.set('source', newSource);
         
         return newSource;
     },
     
+    /* Updates "lastRead" to now, then reconnects */
     markAllAsRead() {
         let rightNow = Math.round(new Date().getTime() / 1000);
-        console.log('Setting lastRead = ', rightNow);
+        DEBUG && console.log('Setting lastRead = ', rightNow);
         localStorage.setItem('lastRead', rightNow);
         
-        // Reconnect
+        // TODO: Maintain a history of acknowledged alerts?
+        this.set('events', A([]));
+        this.set('showNotificationStream', false);
+        
+        // Reconnect with new parameters
         this.connect();
     },
     
@@ -49,8 +69,31 @@ export default Service.extend({
         const self = this;
         let source = self.get('source');
         if (source != null && source.readyState == EventSource.CLOSED) {
-            console.log('Closing connection...');
+            DEBUG && VERBOSE && console.log('Closing connection...');
             source.close();
+        }
+    },
+    
+    onMessage(event) {
+        const self = this;
+        // Parse event data (tale) into JSON
+        event.json = JSON.parse(event.data);
+        event.created = new Date(event.json.time).toLocaleString();
+        //console.log("Message recv'd:", event);
+        
+        // Push new event data
+        let events = self.get('events');
+        if (event.json.type == 'wt_image_build_status') {
+            // TODO: Handle updates to previous events
+            events.unshiftObject(event);
+            self.set('events', events);
+            console.log("New event:", events);
+            self.set('showNotificationStream', true);
+        } else if (event.json.type == 'wt_error_backend_generic') {
+            // NOTE: This is currently unused
+            console.log("Generic backend encountered:", event);
+        } else {
+            console.log("Ignored event type encountered:", event);
         }
     },
 });

--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -83,8 +83,15 @@ export default Service.extend({
         
         // Push new event data
         let events = self.get('events');
+        const createdEq = (e1, e2) => e1.created === e2.created;
+        const idEq = (e1, e2) => e1.json._id === e2.json._id;
+        const found = events.some(prior => idEq(prior, event) && createdEq(prior, event));
+        
+        // Short-circuit for previously-encountered events
+        // TODO: Handle updates properly
+        if (found) return;
+
         if (event.json.type == 'wt_image_build_status') {
-            // TODO: Handle updates to previous events
             events.unshiftObject(event);
             self.set('events', events);
             console.log("New event:", events);

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -405,7 +405,6 @@ ui.inverted.menu.wt.top {
 
 .ui.vertical.menu.tales .item {
   position: relative;
-  padding: 1em 1em 1.25em 6em;
   border-left: 4px solid transparent;
   min-height: 6.3rem;
 }
@@ -441,8 +440,19 @@ ui.inverted.menu.wt.top {
 }
 
 .ui.vertical.menu.tales .item i {
-  float: right;
   position: relative;
+}
+
+.pull-left {
+  float: left;
+}
+
+.pull-right {
+  float: right;
+}
+
+.tale-instances-name {
+  margin: 1em 1em 1.25em 6em;
 }
 
 .ui.vertical.menu.tales .item p {
@@ -1285,4 +1295,8 @@ wt.panel .wt.paddleboard.header i {
   height: stretch;
   height: -webkit-fill-available;
   height: -o-fill-available;
+}
+
+.tale-instances-item {
+  height: 56px;
 }

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -1243,7 +1243,6 @@ wt.panel .wt.paddleboard.header i {
 /** Notification Stream styles */
 #event-notification-counter {
   margin-top: 45px !important;
-  z-index: 1;
   border-radius: 999px;
   padding: 2px 4px;
   text-align: center;
@@ -1253,7 +1252,6 @@ wt.panel .wt.paddleboard.header i {
 }
 #event-notification-stream {
   position: fixed;
-  z-index: 2;
   top: 32px;
   left: 70vw;
   width: 26vw;

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -1240,9 +1240,42 @@ wt.panel .wt.paddleboard.header i {
   }
 }
 
+/** Notification Stream styles */
+#event-notification-counter {
+  margin-top: 45px !important;
+  z-index: 1;
+  border-radius: 999px;
+  padding: 2px 4px;
+  text-align: center;
+}
+#event-notification-placeholder {
+  margin-top: 40px;
+}
+#event-notification-stream {
+  position: fixed;
+  z-index: 2;
+  top: 32px;
+  left: 70vw;
+  width: 26vw;
+  background: #fff;
+  box-shadow: 0 0 4px rgba(0,0,0,.2);
+  border: 1px solid rgba(0,0,0,.2);
+  border-radius: 1rem;
+  padding-bottom: 15px;
+  max-height: 40vh;
+  overflow-y: auto;
+}
 #event-notification-stream > .event > .content > .summary {
   margin-left: 8px;
   font-weight: 400;
+}
+#ack-all-events-button {
+  border-radius: 1rem 1rem 0 0;
+}
+.event-icon {
+  padding:0 !important;
+  margin: 9px 12px !important;
+  font-size: 2.5em !important;
 }
 
 #instance-deleting-loader {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -13,3 +13,5 @@
 {{ui/files/share-access-modal}}
 {{ui/event-notifier}}
 {{ui/job-watcher isLoading=isLoadingJobs jobs=jobs refreshJobs=(action "refreshJobs")}}
+{{ui/notification-stream}}
+

--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -137,5 +137,3 @@
         </div>
     {{/if}}
 </div>
-
-{{ui/notification-stream}}

--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -53,6 +53,15 @@
               data-tooltip="Read the Whole Tale User Guide." data-position="bottom right">
                 <i class="info circle white large icon"></i>
             </a>
+            <a class="item wt thin not-nav" target="_blank" {{action 'toggleShowNotifications'}}
+              href="#" data-tooltip="Show or hide server notifications." data-position="bottom right">
+                <i class="exclamation circle white large icon"></i>
+                {{#if (gt notificationStream.events.length 0)}}
+                    <div id="event-notification-counter" class="floating ui red label">
+                        {{ notificationStream.events.length }}
+                    </div>
+                {{/if}}
+            </a>
             <a class="item wt thin not-nav" {{action 'closeMenu' 'logout'}} 
               data-tooltip="Log out from the Whole Tale." data-position="bottom right">
                 <i class="sign out white large icon"></i>
@@ -99,6 +108,11 @@
                             </a>
                         </li>
                         <li class="bm-menu-item">
+                            <a target="_blank" {{action 'toggleShowNotifications'}}>
+                                <i class="info circle black icon"></i> {{if showNotificationStream 'Hide' 'Show'}} Notifications
+                            </a>
+                        </li>
+                        <li class="bm-menu-item">
                             <a {{action 'closeMenu' 'logout'}}>
                                 <i class="sign out black icon"></i> Log Out
                             </a>
@@ -123,3 +137,5 @@
         </div>
     {{/if}}
 </div>
+
+{{ui/notification-stream}}


### PR DESCRIPTION
### Problem
The notification stream covers up important bits of the UI, with no way to get rid of it unless the events are acknowledged. This presents problems if the user needs to click beneath the feed, but is not yet ready to acknowledge all notifications.

### Approach
* Refactored `notification-stream` to move the actual `events` array out of the component and into the service
* Added a button to the navbar to toggle display of the notification stream
    * Moved existing `notification-stream` component to `header.hbs` / `application.js`
    * Added a badge/label on the button to show the number of notifications currently displayed at a glance

#### TODOs
* Still need to investigate the ability to "update" an existing notification - valid test case needed
* Investigate using a draggable modal for this? Save last coordinates in localStorage? 

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Compose or Launch a Tale
    * You should see the event feed automatically show itself when a new event arrives (e.g. Tale image is building)
4. Click the new (!) button in the Dashboard's Navbar
    * The event feed should be hidden
    * You should still see the red counter/badge indicating how many events are in the feed
5. Click the (!) button again
    * The event feed should redisplay
6. Click the "Mark All as Read" button in the event feed
    * The event feed should be hidden once again
    * You should no longer see the red counter/badge, as there are no events in the feed
7. Click the (!) button one more time
    * The event feed should redisplay
    * You should see a placeholder message indicating that you have received `No new events`