### PR TITLE
Display Tale's Creator if there are no Authors present

### DIFF
--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -7,7 +7,7 @@
                     <img class="env" src="{{model.tale.icon}}" />
                     <div class="header name">
                         <h3>{{truncate-name model.name}}</h3>
-                        <span>{{tale-authors-to-str model.tale.authors}}</span>
+                        <span>{{tale-authors-to-str model.tale.authors model.tale.creator}}</span>
                     </div>
                 </div>
                 <div class="right borderless menu">

--- a/app/components/ui/tale-browser/template.hbs
+++ b/app/components/ui/tale-browser/template.hbs
@@ -243,7 +243,7 @@
                                     </div>
                                 </td>
                                 <td>
-                                    <div style="color: #67c096; font-size: 75%">{{tale-authors-to-str model.authors}}</div>
+                                    <div style="color: #67c096; font-size: 75%">{{tale-authors-to-str model.authors model.creator}}</div>
                                 </td>
                                 <td style="text-align: center;">
                                     {{#if (eq tale_instantiating_id model.id)}}
@@ -333,11 +333,7 @@
                             </div>
                             <div style="padding: 4px"></div>
                             <div style="color: #67c096">
-                                {{#if model.authors}}
-                                    {{tale-authors-to-str model.authors}}
-                                {{else}}
-                                    &nbsp;
-                                {{/if}}
+                                {{tale-authors-to-str model.authors model.creator}}
                             </div>
                             <div style="padding: 8px"></div>
                             <div class="ui right aligned grid" style="padding: 0; float: right;">

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -9,36 +9,42 @@
     <div class="inline fields ui grid">
       <label class="two wide column right aligned">Authors</label>
     </div>
-    {{#each taleAuthors as |author index|}}
-    <div class="inline fields ui grid">
-      <label class="two wide column right aligned"></label>
-      <div class="field thirteen wide column" id=author.id>
-        <div class="ui form">
-          <div class="inline fields">
-            <label>First Name:</label>
+    {{#if taleAuthors}}
+        {{#each taleAuthors as |author index|}}
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned"></label>
+          <div class="field thirteen wide column" id="author-{{index}}">
+            <div class="ui form">
+              <div class="inline fields">
+                <label>First Name:</label>
+                  <div class="field">
+                    {{input type="text" name='first-name' value=author.firstName placeholder="First Name" readonly=cannotEditTale }}
+                  </div>
+                <label>Last Name:</label>
+                <div class="field">
+                  {{input type="text" name='last-name' value=author.lastName placeholder="Last Name" readonly=cannotEditTale }}
+                </div>
+              <label>ORCID:</label>
               <div class="field">
-                {{input type="text" name='first-name' value=author.firstName placeholder="First Name" readonly=cannotEditTale }}
+                {{input type="url" name='orcid-id' placeholder="https://orcid.org/0000-0002-1825-0097"  value=author.orcid readonly=cannotEditTale }}
               </div>
-            <label>Last Name:</label>
-            <div class="field">
-              {{input type="text" name='last-name' value=author.lastName placeholder="Last Name" readonly=cannotEditTale }}
+              <i class="fa fa-window-close" aria-hidden="true" {{action 'removeAuthor' index}}></i>
             </div>
-          <label>ORCID:</label>
-          <div class="field">
-            {{input type="url" name='orcid-id' placeholder="https://orcid.org/0000-0002-1825-0097"  value=author.orcid readonly=cannotEditTale }}
           </div>
-          <i class="fa fa-window-close" aria-hidden="true" {{action 'removeAuthor' index}}></i>
         </div>
       </div>
-    </div>
-  </div>
-  {{/each}}
+      {{/each}}
+    {{else}}
+      <div style="text-align:center">
+        <h4>Created by <span style="color: #67c096">{{tale-authors-to-str taleAuthors model.tale.creator}}</span></h4>
+      </div>
+    {{/if}}
       
     <div class="inline fields ui grid">
         <label class="two wide column right aligned"></label>
         <div class="field thirteen wide column add-author">
             <i class="fas fa-plus add-author-icon" {{action 'addNewAuthor'}}></i>
-            <span {{action 'addNewAuthor'}}>&nbsp;Add another author</span>
+            <span {{action 'addNewAuthor'}}>&nbsp;Add an{{if taleAuthors 'other'}} author</span>
         </div>
     </div>
 

--- a/app/controllers/run.js
+++ b/app/controllers/run.js
@@ -1,6 +1,8 @@
 import Controller from '@ember/controller';
-import { observer } from '@ember/object';
+import EmberObject, { observer } from '@ember/object';
 import $ from 'jquery';
+
+const O = EmberObject.create.bind(EmberObject);
 
 export default Controller.extend({
   grabData(model) {
@@ -12,13 +14,26 @@ export default Controller.extend({
       controller.get('store').findRecord('tale', item.get('taleId')).then(tale => {
         controller.get('store').findRecord('image', tale.get('imageId')).then(image => {
           item.set('image', image);
-          controller.get('store').findRecord('folder', tale.get('folderId')).
-            then(folder => {
-              item.set('folder', folder);
+          controller.get('store').findRecord('user', tale.get('creatorId')).
+            then(creator => {
+              tale.set('creator', O({
+                firstName: creator.firstName,
+                lastName: creator.lastName,
+                orcid: ''
+              }));
+              item.set('tale', O(tale));
+              controller.get('store').findRecord('folder', tale.get('folderId')).
+              then(folder => {
+                item.set('folder', folder);
+              }).catch(() => {
+                let err = controller.get("error") + "<li>Folder with ID " + tale.get('folderId') + " was not found for tale " + tale.get('title') + "!</li>";
+                controller.set("error", err);
+              });
             }).catch(() => {
-              let err = controller.get("error") + "<li>Folder with ID " + tale.get('folderId') + " was not found for tale " + tale.get('title') + "!</li>";
+              let err = controller.get("error") + "<li>User with ID " + tale.get('creatorId') + " was not found for tale " + tale.get('title') + "!</li>";
               controller.set("error", err);
             });
+          
         }).catch(() => {
           let err = controller.get("error") + "<li>Image with ID " + tale.get('imageId') + " was not found for tale " + tale.get('title') + "! </li>";
           controller.set("error", err);

--- a/app/controllers/tale/view.js
+++ b/app/controllers/tale/view.js
@@ -44,6 +44,17 @@ export default Controller.extend({
     console.log("Controller model hook is called from nested tale 'view'");
     let model = this.get('model'); // this is assigned but never used!
   }),
+  creatorObserver: observer('model.creatorId', function() {
+    const model = this.get('model');
+    const creatorId = model.get("creatorId");
+    this.store.findRecord('user', creatorId).then(creator => {
+      this.get("model").set('creator', {
+        firstName: creator.firstName,
+        lastName: creator.lastName,
+        orcid: ''
+      });
+    })
+  }),
   isOwner: computed('model.creatorId', 'user_id', function () {
     const user_id = this.get("user_id");
     const creator_id = this.get("model").get("creatorId");

--- a/app/helpers/tale-authors-to-str.js
+++ b/app/helpers/tale-authors-to-str.js
@@ -1,5 +1,9 @@
 import { helper } from '@ember/component/helper';
 
+const authorToStr = function (author) {
+  return `${author.firstName} ${author.lastName}`;
+};
+
     /**
     * Takes a list of authors from the backend and returns a string of first
     * and last names that can be shown in the UI.
@@ -13,21 +17,23 @@ import { helper } from '@ember/component/helper';
     * track of the current position.
     * 
     * @method taleAuthorsToStr
-    * @param params A list of JSON Tale authors [{author1}, {author2}, etc]
+    * @param param0 A list of JSON Tale authors [{author1}, {author2}, etc]
+    * @param param1 A user to display by default if no authors are present (e.g. creator)
     */
 export function taleAuthorsToStr(params/*, hash*/) {
   // String that will be shown to the UI.
-  let allAuthors = String();
-  params = params[0]
-  if(params) {
-    for(let position=0; position<params.length; position++) {
-      let author = params[position];
-      if (position>=1 && position<params.length) {
-        // If there are more than one authors and we aren't at the last one
-        allAuthors += ', '
+  let allAuthors = '';
+  const authors = params[0];
+  const creator = params[1];
+  if (authors && authors.length) {
+    for (let i = 0; i < authors.length; i++) {
+      if (i > 0) {
+         allAuthors += ', ';
       }
-    allAuthors += author.firstName + ' ' + author.lastName;
+      allAuthors += authorToStr(authors[i]);
     }
+  } else if (creator) {
+    allAuthors = authorToStr(creator);
   }
   return allAuthors;
 }

--- a/app/templates/tale/view.hbs
+++ b/app/templates/tale/view.hbs
@@ -75,7 +75,7 @@
                                 <div class="eight wide column">
                                     <div class="ui huge header" style="margin: 0 0 5px 0"> {{model.title}} </div>
                                     <div class="ui header" style="margin: 0 0 5px 0">
-                                        By <span style="color: #67c096">{{tale-authors-to-str model.authors}} </span>
+                                        By <span style="color: #67c096">{{tale-authors-to-str model.authors model.creator}} </span>
                                     </div>
                                 </div>
                                 <div class="eight wide right aligned column">


### PR DESCRIPTION
### Problem
With the recent changes to the backend, Compose now produces a Tale without any authors. It looks odd in the UI to see a blank spot where the authors should be.

### Approach
Fetch the Tale's creator and display it if the authors are not present. This could be optimized to only fetch if the Tale has no authors, but this should work fine for now.

### How to Test
Prerequisites: Synchronize `wholetale` and `gwvolman` with `master` (https://github.com/whole-tale/deploy-dev/pull/19/files#diff-b729f8c7e84b10f0951865e6a50056fc contains a super primitive script for this)

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. If you haven't already: compose a new Tale, add an author (via `Run > Metadata`), and Save
4. If you haven't already: compose a new Tale, but this time **DO NOT** add an author
5. Navigate to Browse
    * You should see both Tales show the name of an author in green
    * Note that one of these Tales is displaying the creator, and the other is displaying a list of authors
6. From Browse, click "View" (for each Tale)
    * Each `Tale View` page should list the same authors/creator as you saw on the Browse page
7. Navigate to Run > Metadata for the Tale the authorless Tale
    * You should see a placeholder message reading `Created By _________`
8. Click "Add an Author" below the placeholder message
    * The placeholder message should disappear
    * You should see an empty "Author Row" appear in place of the placeholder
    * You should see that the button text has changed to "Add another author"