### PR TITLE
Open the publish modal when auth=true

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -116,7 +116,8 @@ export default Component.extend(FullScreenMixin, {
           let queryParams = this.get('params')
           if (queryParams) {
             if (queryParams.auth === 'true') {
-              this.send('openPublishModal', this.model.taleId)
+              this.router.transitionTo({ queryParams: { auth: null }});
+              this.send('openPublishModal', this.model.taleId);
             }
           }
         });

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -14,7 +14,7 @@ const O = EmberObject.create.bind(EmberObject);
 export default Component.extend(FullScreenMixin, {
     layout,
     classNames: ['run-left-panel'],
-    router: service('-routing'),
+    router: service(),
     internalState: service(),
     apiCall: service('api-call'),
     dataoneAuth: service('dataone-auth'),

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -5,7 +5,7 @@ import config from '../../../../config/environment';
 import { scheduleOnce, later, cancel } from '@ember/runloop';
 import EmberObject, { computed } from '@ember/object';
 import { A } from '@ember/array';
-import { not } from '@ember/object/computed';
+import { not, alias } from '@ember/object/computed';
 import $ from 'jquery';
 import layout from './template';
 
@@ -27,6 +27,8 @@ export default Component.extend(FullScreenMixin, {
     displayTaleInstanceMenu: false,
     workspaceRootId: undefined,
     session: O({dataSet:A()}),
+    routing: service('-routing'),
+    params: alias('routing.router.currentState.routerJsState.fullQueryParams'),
 
     // Holds an array of objects that the user cannot be exclude from their package
     nonOptionalFile: [
@@ -110,12 +112,13 @@ export default Component.extend(FullScreenMixin, {
 
     didInsertElement() {
         scheduleOnce('afterRender', this, () => {
-            // Check if we're coming from an ORCID redirect
-            // If ?auth=true
-            // Open Modal
-            const modalDialogName = 'ui/files/republish-modal';
-            this.showModal(modalDialogName, this.get('modalContext'));
-        
+          // Check if we're coming from an ORCID redirect
+          let queryParams = this.get('params')
+          if (queryParams) {
+            if (queryParams.auth === 'true') {
+              this.send('openPublishModal', this.model.taleId)
+            }
+          }
         });
         
         $('.ui.accordion').accordion({});


### PR DESCRIPTION
Fixes issue #466 

This small change opens the publishing modal when the `auth` queryParam is true

To test:
1. Check `fix_auth_popup` out
2. Navigate to the run page
3. Sign out of DataONE
4. Open the publish modal
5. Sign in
6. After you are re-directed back to whole tale, note `auth=true` in the URL
7. The dialog should open