### PR TITLE
Add action to generate a new Tale illustration

### DIFF
--- a/app/components/ui/tale-tab-metadata/component.js
+++ b/app/components/ui/tale-tab-metadata/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
 import $ from 'jquery';
 
@@ -15,6 +16,7 @@ const taleStatus = Object.create({
 
 
 export default Component.extend({
+  store: service(),
   apiHost: config.apiHost,
   environments: [],
   licenses: [],
@@ -204,5 +206,21 @@ export default Component.extend({
       $(selector).modal('setting', 'closable', true);
       $(selector).modal('show');
     },
+
+    /**
+     * Generates an illustration for the tale.
+     * @method generateIcon
+    */
+    generateIcon() {
+      this.get('store').query('sils', {
+        text: encodeURI(this.taleAuthors)
+      })
+        .then(sils => {
+          sils.forEach(result => {
+            let tale = this.get('model').get('tale');
+            tale.set('illustration', result.get('icon'));
+          })
+        });
+    },    
   }
 });

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -134,7 +134,7 @@
             {{input id=tale-icon value=model.tale.illustration placeholder="http://" readonly=cannotEditTale}}
             <div class="ui buttons">
                 <div class="or"></div>
-                <button class="ui positive blue button" {{action "generateIcon" model.tale}}>Generate Illustration</button>
+                <button class="ui positive blue button" {{action "generateIcon"}}>Generate Illustration</button>
             </div>
         </div>
     </div>
@@ -176,3 +176,4 @@
         </div>
     </div>
 </div>
+


### PR DESCRIPTION
The method I added is similar to [this one](https://github.com/whole-tale/dashboard/blob/master/app/controllers/tale/view.js#L293) on the Tale view page.

To Test:
1. Check this branch out
2. Launch a Tale
3. Navigate to the metadata tab
4. Generate a new icon
5. Save the Tale
6. Refresh the page and check that the change persisted
7. Note that the Tale icon has changed

Fixes issue #469 