### PR TITLE
Add production flags to dataone repositories

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -162,8 +162,6 @@ export default Component.extend(FullScreenMixin, {
      * @method createTooltips
      */
     createTooltips() {
-        console.log('Creating tooltips...');
-        
         // Create the popup in the main title
         $('.info.circle.blue.icon.main').popup({
           position: 'right center',

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -43,18 +43,18 @@ export default Component.extend(FullScreenMixin, {
     // An array of repositories to list in the dropdown and their matching url
     repositories: [{
       name: 'DataONE Development',
-      url: 'https://dev.nceas.ucsb.edu/knb/d1/mn',
-      isProduction: false
+      memberNode: 'https://dev.nceas.ucsb.edu/knb/d1/mn',
+      coordinatingNode: 'https://cn-stage-2.test.dataone.org/cn/v2'
     },
     {
       name: 'DataONE-The Knowledge Network for Biocomplexity',
-      url: 'https://knb.ecoinformatics.org/knb/d1/mn',
-      isProduction: true
+      memberNode: 'https://knb.ecoinformatics.org/knb/d1/mn',
+      coordinatingNode: 'https://cn.dataone.org/cn/v2'
     },
     {
       name: 'DataONE-Arctic Data Center',
-      url: 'https://arcticdata.io/metacat/d1/mn',
-      isProduction: true
+      memberNode: 'https://arcticdata.io/metacat/d1/mn',
+      coordinatingNode: 'https://cn.dataone.org/cn/v2'
     }],
     
     repoDropdownClass: computed('publishStatus', function() {
@@ -340,9 +340,9 @@ export default Component.extend(FullScreenMixin, {
           window.location.assign(url + '?token=' + token + '&taleFormat=' + format);
         },
         
-        authenticateD1(taleId, isProduction) {
+        authenticateD1(taleId, coordinatingNode) {
           let callback = `${this.get('wholeTaleHost')}/run/${taleId}?auth=true`;
-          let endpoint = this.dataoneAuth.getEndpoint(isProduction)
+          let endpoint = this.dataoneAuth.getPortalEndpoint(coordinatingNode)
           endpoint += '/oauth?action=start&target=';
           window.location.replace(endpoint + callback);
       },
@@ -366,7 +366,7 @@ export default Component.extend(FullScreenMixin, {
             let targetRepo = self.get('selectedRepositoryName');
             let repository = self.getRepositoryFromName(targetRepo);
 
-            let dataOneJWT = this.dataoneAuth.getDataONEJWT(repository.isProduction)
+            let dataOneJWT = this.dataoneAuth.getDataONEJWT(repository.coordinatingNode)
             if (!dataOneJWT) {
               // reroute to auth
               $('#dataone-auth-modal').modal('show');
@@ -377,7 +377,7 @@ export default Component.extend(FullScreenMixin, {
             self.set('progress', 0);            
 
             // Call the publish endpoint
-            self.get("apiCall").publishTale(tale._id, repository.url, dataOneJWT, repository.isProduction)
+            self.get("apiCall").publishTale(tale._id, repository.memberNode, repository.coordinatingNode, dataOneJWT)
                 .then((publishJob) => {
                     console.log('Submitted for publish:', publishJob);
                     self.set('publishStatus', 'in_progress');

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -16,9 +16,9 @@ export default Component.extend(FullScreenMixin, {
     classNames: ['run-left-panel'],
     router: service(),
     internalState: service(),
+    store: service(),
     apiCall: service('api-call'),
     dataoneAuth: service('dataone-auth'),
-    dataoneJWT: null,
     tokenHandler: service('token-handler'),
     loadError: false,
     model: null,
@@ -29,6 +29,7 @@ export default Component.extend(FullScreenMixin, {
     session: O({dataSet:A()}),
     routing: service('-routing'),
     params: alias('routing.router.currentState.routerJsState.fullQueryParams'),
+    selectedRepository: '',
 
     // Holds an array of objects that the user cannot be exclude from their package
     nonOptionalFile: [
@@ -42,15 +43,18 @@ export default Component.extend(FullScreenMixin, {
     // An array of repositories to list in the dropdown and their matching url
     repositories: [{
       name: 'DataONE Development',
-      url: 'https://dev.nceas.ucsb.edu/knb/d1/mn'
+      url: 'https://dev.nceas.ucsb.edu/knb/d1/mn',
+      isProduction: false
     },
     {
       name: 'DataONE-The Knowledge Network for Biocomplexity',
-      url: 'https://knb.ecoinformatics.org/knb/d1/mn'
+      url: 'https://knb.ecoinformatics.org/knb/d1/mn',
+      isProduction: true
     },
     {
       name: 'DataONE-Arctic Data Center',
-      url: 'https://arcticdata.io/metacat/d1/mn'
+      url: 'https://arcticdata.io/metacat/d1/mn',
+      isProduction: true
     }],
     
     repoDropdownClass: computed('publishStatus', function() {
@@ -116,32 +120,17 @@ export default Component.extend(FullScreenMixin, {
           let queryParams = this.get('params')
           if (queryParams) {
             if (queryParams.auth === 'true') {
-              this.router.transitionTo({ queryParams: { auth: null }});
-              this.send('openPublishModal', this.model.taleId);
-            }
+              this.get('store').findRecord('tale', this.model.taleId, {
+                reload: true
+              })
+              .then(resp => {
+              this.send('openPublishModal', resp)
+            })
           }
-        });
-        
+          }
+        })   
+
         $('.ui.accordion').accordion({});
-    },
-
-    /*
-        Return s the DataONE `token` endpoint for the jwt. When a user signs into
-        DataONE a cookie is created, which is checked by `token`. If the cookie wasn't
-        found, then the response will be empty. Otherwise the jwt is returned.
-    */
-    getDataONEJWT() {
-
-        // Use the XMLHttpRequest to handle the request
-        let xmlHttp = new XMLHttpRequest();
-        // Open the request to the the token endpoint, which will return the jwt if logged in
-        xmlHttp.open("GET", 'https://cn-stage-2.test.dataone.org/portal/token', false);
-        // Set the response content type
-        xmlHttp.setRequestHeader("Content-Type", "text/xml");
-        // Let XMLHttpRequest know to use cookies
-        xmlHttp.withCredentials = true;
-        xmlHttp.send(null);
-        return xmlHttp.responseText;
     },
 
     shouldShowButtons: computed('internalState', 'internalState.currentInstanceId', function () {
@@ -156,10 +145,6 @@ export default Component.extend(FullScreenMixin, {
 
     noInstanceSelected: not('hasSelectedTaleInstance'),
 
-    hasD1JWT: computed('model.taleId', function () {
-        let jwt = this.getDataONEJWT();
-        return (jwt && jwt.length) ? true : false;
-    }),
 
     showModal(modalDialogName, modalContext) {
         // Open Publish Modal
@@ -167,7 +152,7 @@ export default Component.extend(FullScreenMixin, {
     },
 
     publishModalContext: computed('model.taleId', function () {
-        return { taleId: this.get('model.taleId'), hasD1JWT: this.hasD1JWT };
+        return { taleId: this.get('model.taleId'), hasD1JWT: this.dataoneAuth.hasD1JWT };
     }),
 
 
@@ -231,12 +216,12 @@ export default Component.extend(FullScreenMixin, {
         });
     },
     
-    getRepositoryPathFromName(name) {
+    getRepositoryFromName(name) {
         // Given a repository name, find the membernode URL
         let repositoryList = this.get('repositories');
         for (var i = 0; i < repositoryList.length; i++) {
           if (repositoryList[i].name === name) {
-            return repositoryList[i].url;
+            return repositoryList[i];
           }
         }
     },
@@ -337,12 +322,6 @@ export default Component.extend(FullScreenMixin, {
             this.get('showModal')(modalDialogName, modalContext);
         },
 
-        authenticateD1(taleId) {
-            let callback = `${this.get('wholeTaleHost')}/run/${taleId}?auth=true`;
-            let orcidLogin = 'https://cn-stage-2.test.dataone.org/portal/oauth?action=start&target=';
-            window.location.replace(orcidLogin + callback);
-        },
-
         openDeleteModal(id) {
             let selector = '.ui.' + id + '.modal';
             $(selector).modal('show');
@@ -361,38 +340,44 @@ export default Component.extend(FullScreenMixin, {
           window.location.assign(url + '?token=' + token + '&taleFormat=' + format);
         },
         
-        openPublishModal(tale) {
-            const jwt = this.getDataONEJWT();
-            if (!jwt) {
-                // reroute to auth
-                $('#dataone-auth-modal').modal('show');
-                return;
-            }
-            
-            this.set('dataoneJWT', jwt);
+        authenticateD1(taleId, isProduction) {
+          let callback = `${this.get('wholeTaleHost')}/run/${taleId}?auth=true`;
+          let endpoint = this.dataoneAuth.getEndpoint(isProduction)
+          endpoint += '/oauth?action=start&target=';
+          window.location.replace(endpoint + callback);
+      },
+
+        openPublishModal(tale) {          
             this.resetPublishState();
             this.set('taleToPublish', tale);
-            this.set('selectedRepository', null);
+            this.set('selectedRepositoryName', null);
             const self = this;
             $('#publish-modal').modal({ 
                 onApprove: () => false,
                 onDeny: () => false,
-                onVisible: () => { self.set('selectedRepository', self.get('repositories')[0].name); }
+                onVisible: () => { self.set('selectedRepositoryName', self.get('repositories')[0].name); }
             }).modal('show');
         },
         
-
         submitPublish(tale) {
             const self = this;
             console.log('Now publishing:', tale);
+
+            let targetRepo = self.get('selectedRepositoryName');
+            let repository = self.getRepositoryFromName(targetRepo);
+
+            let dataOneJWT = this.dataoneAuth.getDataONEJWT(repository.isProduction)
+            if (!dataOneJWT) {
+              // reroute to auth
+              $('#dataone-auth-modal').modal('show');
+              return;
+          }
+
             self.set('publishStatus', 'in_progress');
-            self.set('progress', 0);
-            const targetRepo = self.get('selectedRepository');
-            const repository = self.getRepositoryPathFromName(targetRepo);
-            const dataOneJWT = this.get('dataoneJWT');
-            
+            self.set('progress', 0);            
+
             // Call the publish endpoint
-            self.get("apiCall").publishTale(tale._id, repository, dataOneJWT)
+            self.get("apiCall").publishTale(tale._id, repository.url, dataOneJWT, repository.isProduction)
                 .then((publishJob) => {
                     console.log('Submitted for publish:', publishJob);
                     self.set('publishStatus', 'in_progress');
@@ -420,7 +405,9 @@ export default Component.extend(FullScreenMixin, {
         onRepositoryChange: function () {
           // Called when the user changes the repository
           let respText = $('.repository.selection.dropdown.ui.dropdown').dropdown('get text')
-          this.set('selectedRepository', respText);
+          this.set('selectedRepositoryName', respText);
+          let repository = this.getRepositoryFromName(respText);
+          this.set('selectedRepository', repository)
         },
     }
 });

--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -11,6 +11,12 @@ import layout from './template';
 
 const O = EmberObject.create.bind(EmberObject);
 
+/**
+ * Responsible for the run page view. It contains logic for
+ * tale exporting and publishing.
+ *
+ * @class RunLeftPanelComponent
+*/
 export default Component.extend(FullScreenMixin, {
     layout,
     classNames: ['run-left-panel'],
@@ -90,10 +96,14 @@ export default Component.extend(FullScreenMixin, {
         };
     },
 
+    /**
+     * Similar to Jquery on page load doesn't work
+     * because of the handlebars. But even if you unhide the element,
+     * the iframes show that they load ok even though some are blocked and some are not.
+     *
+     * @method didRender
+    */
     didRender() {
-        // Similar to Jquery on page load
-        // doesn't work because of the handlebars. But even if you unhide the element, the iframes show
-        // that they load ok even though some are blocked and some are not.
         let frame = document.getElementById('frontendDisplay');
         if (frame) {
             frame.onload = () => {
@@ -114,6 +124,13 @@ export default Component.extend(FullScreenMixin, {
         this.createTooltips();
     },
 
+  
+    /**
+     * Used to check for the ?auth=true query parameter and potentially
+     * open the publish modal
+     *
+     * @method didInsertElement
+    */
     didInsertElement() {
         scheduleOnce('afterRender', this, () => {
           // Check if we're coming from an ORCID redirect
@@ -160,7 +177,7 @@ export default Component.extend(FullScreenMixin, {
      * Creates the tooltips that appear in the dialog
      * 
      * @method createTooltips
-     */
+    */
     createTooltips() {
         // Create the popup in the main title
         $('.info.circle.blue.icon.main').popup({
@@ -214,6 +231,15 @@ export default Component.extend(FullScreenMixin, {
         });
     },
     
+
+    /**
+     * Handles querying the backend for the publishing job status and updating
+     * the progress bar.
+     *
+     * @method handlePublishingStatus
+     * @param tale The Tale that is being published
+     * @param joId The ID of the job that is responsible for publishing
+    */
     handlePublishingStatus(tale, jobId) {
         let self = this;
         let currentLoop = null;
@@ -265,11 +291,11 @@ export default Component.extend(FullScreenMixin, {
         currentLoop = startLooping();
     },
 
-    /* 
+    /**
      * Retrieves a human readable error from job/result
      * 
-     * @method closeModal
-     */
+     * @method setErrorStatus
+    */
     setErrorStatus(jobId) {
         const self = this;
         let onGetJobStatusSuccess = (message) => {
@@ -281,9 +307,14 @@ export default Component.extend(FullScreenMixin, {
             .then(onGetJobStatusSuccess)
             .catch(onGetJobStatusSuccess);
     },
-        
+
+
+    /**
+     * Resets the state of the publish modal properties
+     *
+     * @method resetPublishState
+    */
     resetPublishState() {
-        // Reset any leftover previous state
         this.set('progress', null);
         this.set('statusMessage', null);
         this.set('taleToPublish', null);
@@ -329,10 +360,10 @@ export default Component.extend(FullScreenMixin, {
         },
 
         /**
-        * Redirect to the selected repository's authentication portal.
-        *
-        * @method authenticateD1
-        * @param instanceId The ID of the running instance
+         * Redirect to the selected repository's authentication portal.
+         *
+         * @method authenticateD1
+         * @param instanceId The ID of the running instance
         */
         authenticateD1(instanceId) {
           let callback = `${this.get('wholeTaleHost')}/run/${instanceId}?auth=true`;
@@ -341,6 +372,12 @@ export default Component.extend(FullScreenMixin, {
           window.location.replace(endpoint + callback);
       },
 
+        /**
+         * Opens the publishing modal and sets initial state.
+         *
+         * @method openPublishModal
+         * @param tale The Tale that is going to be published
+        */
         openPublishModal(tale) {          
             this.resetPublishState();
             this.set('taleToPublish', tale);
@@ -352,6 +389,13 @@ export default Component.extend(FullScreenMixin, {
             }).modal('show');
         },
         
+        /**
+         * Retrieves the user's JWT, handles routing to ORCID if needed, and
+         * sends relevant information to the backend to start publishing,
+         *
+         * @method submitPublish
+         * @param tale The Tale that is going to be published
+        */
         submitPublish(tale) {
             const self = this;
 
@@ -387,15 +431,21 @@ export default Component.extend(FullScreenMixin, {
             return false;
         },
         
+        /**
+         * Closes the publishing modal and resets the state so that the user
+         * sees a fresh state when it's re-opened
+         *
+         * @method closePublishModal
+        */
         closePublishModal() {
             $('#publish-modal').modal('hide');
             this.resetPublishState();
         },
 
         /**
-        * Called when the user selects a repository in the dropdown menu.
-        *
-        * @method onRepositoryChange
+         * Called when the user selects a repository in the dropdown menu.
+         *
+         * @method onRepositoryChange
         */
         onRepositoryChange: function () {
           let repositoryName = $('.repository.selection.dropdown.ui.dropdown').dropdown('get text');

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -99,7 +99,7 @@
             <div class="ui black deny button">
                 Cancel
             </div>
-            <div class="ui positive right labeled icon button" {{action 'authenticateD1' model._id selectedRepository.isProduction}}>
+            <div class="ui positive right labeled icon button" {{action 'authenticateD1' model._id selectedRepository.coordinatingNode}}>
                 Continue to DataOne Login
                 <i class="checkmark icon"></i>
             </div>

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -99,7 +99,7 @@
             <div class="ui black deny button">
                 Cancel
             </div>
-            <div class="ui positive right labeled icon button" {{action 'authenticateD1' model._id}}>
+            <div class="ui positive right labeled icon button" {{action 'authenticateD1' model._id selectedRepository.isProduction}}>
                 Continue to DataOne Login
                 <i class="checkmark icon"></i>
             </div>
@@ -126,7 +126,7 @@
       <div class="ui form" style="margin-bottom:15px;">
           <div class="required inline field">
               <label>Please choose a target repository:</label>
-              {{#ui-dropdown class=repoDropdownClass allowAdditions=false selected=selectedRepository onChange=(action 'onRepositoryChange')
+              {{#ui-dropdown class=repoDropdownClass allowAdditions=false selected=selectedRepositoryName onChange=(action 'onRepositoryChange')
                 as |execute mapper|}}
                 <div class="default text">Target Repository</div>
                 <i class="dropdown icon"></i>
@@ -192,7 +192,7 @@
           <div class="ui blue message progress-area" id="publishing-progress-message">
             <p class="header publishing-now">
                 <a id="publishing-success-label" class="ui blue label">IN PROGRESS</a>
-                Your Tale is being published to {{selectedRepository}}
+                Your Tale is being published to {{selectedRepository.name}}
             </p>
             <div class="publish-progressbar">
                 {{#ui-progress percent=progress class="teal indicating"}}
@@ -232,8 +232,8 @@
       {{if (eq publishStatus 'success') 'Close' 'Cancel'}}
     </div>
     <div class="ui positive right labeled icon button 
-        {{if (or (eq publishStatus 'success') (or (eq publishStatus 'in_progress') (eq selectedRepository null))) 'disabled'}}" 
-        disabled="{{if (or (eq publishStatus 'success') (or (eq publishStatus 'in_progress') (eq selectedRepository null))) 'true' 'false'}}"
+        {{if (or (eq publishStatus 'success') (or (eq publishStatus 'in_progress') (eq selectedRepositoryName null))) 'disabled'}}" 
+        disabled="{{if (or (eq publishStatus 'success') (or (eq publishStatus 'in_progress') (eq selectedRepositoryName null))) 'true' 'false'}}"
         {{action 'submitPublish' taleToPublish}}>
       {{if (or (eq publishStatus 'initialized') (eq publishStatus 'error')) 'Publish'}}
       {{if (eq publishStatus 'success') 'Published'}}

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -99,7 +99,7 @@
             <div class="ui black deny button">
                 Cancel
             </div>
-            <div class="ui positive right labeled icon button" {{action 'authenticateD1' model._id selectedRepository.coordinatingNode}}>
+            <div class="ui positive right labeled icon button" {{action 'authenticateD1' model._id}}>
                 Continue to DataOne Login
                 <i class="checkmark icon"></i>
             </div>

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -400,13 +400,15 @@ export default Service.extend({
      * @param taleId The ID of the Tale this is being published
      * @param repository 
      * @param jwt The user's DataONE JWT token
+     * @param isProduction Flag set to true when publishing to a production server
      */
-  publishTale(taleId, repository, jwt) {
+  publishTale(taleId, repository, jwt, isProduction) {
       const token = this.get('tokenHandler').getWholeTaleAuthToken();
       return new Promise ((resolve, reject) => {
           let url = `${config.apiUrl}/publish/dataone` + 
             `?taleId=${taleId}&remoteMemberNode=${repository}` + 
-            `&authToken=${jwt}`;
+            `&authToken=${jwt}` +
+            `&isProduction=${isProduction}`;
     
           let client = new XMLHttpRequest();
           client.open('GET', url);

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -398,17 +398,17 @@ export default Service.extend({
      * Publishes a Tale to DataONE
      * @method publishTale
      * @param taleId The ID of the Tale this is being published
-     * @param repository 
+     * @param memberNode 
      * @param jwt The user's DataONE JWT token
-     * @param isProduction Flag set to true when publishing to a production server
+     * @param coordinatingNode The Coordinating node that overlooks the member node
      */
-  publishTale(taleId, repository, jwt, isProduction) {
+  publishTale(taleId, memberNode, coordinatingNode, jwt) {
       const token = this.get('tokenHandler').getWholeTaleAuthToken();
       return new Promise ((resolve, reject) => {
           let url = `${config.apiUrl}/publish/dataone` + 
-            `?taleId=${taleId}&remoteMemberNode=${repository}` + 
+            `?taleId=${taleId}&remoteMemberNode=${memberNode}` + 
             `&authToken=${jwt}` +
-            `&isProduction=${isProduction}`;
+            `&coordinatingNode=${coordinatingNode}`;
     
           let client = new XMLHttpRequest();
           client.open('GET', url);

--- a/app/services/dataone-auth.js
+++ b/app/services/dataone-auth.js
@@ -1,25 +1,29 @@
 import Service from '@ember/service';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
-import config from '../config/environment';
  export default Service.extend({
   tokenHandler: service('token-handler'),
   store: service(),
   authRequest: service(),
   isAuthenticated: true,
-   getDataONEJWT() {
-    /*
-    Queries the DataONE `token` endpoint for the jwt. When a user signs into
-    DataONE a cookie is created, which is checked by `token`. If the cookie wasn't
-    found, then the response will be empty. Otherwise the jwt is returned.
+  devCN: 'https://cn-stage-2.test.dataone.org/portal',
+  prodCN: 'https://cn.dataone.org/portal',
+
+    /**
+     * Queries the DataONE `token` endpoint for the jwt. When a user signs into
+     * DataONE a cookie is created, which is checked by `token`. If the cookie wasn't
+     * found, then the response will be empty. Otherwise the jwt is returned.
+     *
+     * @method getDataONEJWT
+     * @param isProduction Flag set to true when production should be interfaced
     */
-     // Use the XMLHttpRequest to handle the request
+   getDataONEJWT(isProduction) {
     let xmlHttp = new XMLHttpRequest();
-    // Open the request to the the token endpoint, which will return the jwt if logged in
-    let dataoneEndpoint = 'https://cn.dataone.org/portal/token'
-    if (config.dev) {
-      dataoneEndpoint = 'https://cn-stage-2.test.dataone.org/portal/token'
+    let dataoneEndpoint = this.devCN
+    if (isProduction) {
+      dataoneEndpoint = this.prodCN
     }
+    dataoneEndpoint+='/token'
+    console.log('From getDataONEJWT', dataoneEndpoint)
     xmlHttp.open("GET", dataoneEndpoint, false);
     // Set the response content type
     xmlHttp.setRequestHeader("Content-Type", "text/xml");
@@ -28,8 +32,18 @@ import config from '../config/environment';
     xmlHttp.send(null);
     return xmlHttp.responseText;
   },
+
+
    hasD1JWT()  {
     let jwt = this.getDataONEJWT();
     return jwt ? true : false;
   },
+
+  getEndpoint(isProduction) {
+    let dataoneEndpoint = this.devCN;
+    if (isProduction) {
+      dataoneEndpoint = this.prodCN;
+    }
+    return dataoneEndpoint;
+  }
  });

--- a/app/services/dataone-auth.js
+++ b/app/services/dataone-auth.js
@@ -18,7 +18,6 @@ import { inject as service } from '@ember/service';
     let xmlHttp = new XMLHttpRequest();
 
     dataoneEndpoint = this.getPortalEndpoint(dataoneEndpoint)+'/token'
-    console.log('From getDataONEJWT', dataoneEndpoint)
     xmlHttp.open("GET", dataoneEndpoint, false);
     // Set the response content type
     xmlHttp.setRequestHeader("Content-Type", "text/xml");

--- a/app/services/dataone-auth.js
+++ b/app/services/dataone-auth.js
@@ -5,8 +5,6 @@ import { inject as service } from '@ember/service';
   store: service(),
   authRequest: service(),
   isAuthenticated: true,
-  devCN: 'https://cn-stage-2.test.dataone.org/portal',
-  prodCN: 'https://cn.dataone.org/portal',
 
     /**
      * Queries the DataONE `token` endpoint for the jwt. When a user signs into
@@ -14,15 +12,12 @@ import { inject as service } from '@ember/service';
      * found, then the response will be empty. Otherwise the jwt is returned.
      *
      * @method getDataONEJWT
-     * @param isProduction Flag set to true when production should be interfaced
+     * @param dataoneEndpoint The Coordinating node address (with the version)
     */
-   getDataONEJWT(isProduction) {
+   getDataONEJWT(dataoneEndpoint) {
     let xmlHttp = new XMLHttpRequest();
-    let dataoneEndpoint = this.devCN
-    if (isProduction) {
-      dataoneEndpoint = this.prodCN
-    }
-    dataoneEndpoint+='/token'
+
+    dataoneEndpoint = this.getPortalEndpoint(dataoneEndpoint)+'/token'
     console.log('From getDataONEJWT', dataoneEndpoint)
     xmlHttp.open("GET", dataoneEndpoint, false);
     // Set the response content type
@@ -39,11 +34,13 @@ import { inject as service } from '@ember/service';
     return jwt ? true : false;
   },
 
-  getEndpoint(isProduction) {
-    let dataoneEndpoint = this.devCN;
-    if (isProduction) {
-      dataoneEndpoint = this.prodCN;
-    }
-    return dataoneEndpoint;
+    /**
+     * Takes a coordinating node and returns the portal endpoint.
+     *
+     * @method getPortalEndpoint
+     * @param coordinatingNode The Coordinating node address (with the version)
+    */
+  getPortalEndpoint(coordinatingNode) {
+    return coordinatingNode.replace('cn/v2', 'portal')
   }
  });


### PR DESCRIPTION
We need to tell whether we're publishing to production or dev DataONE. This PR 

1. Sends the user to prod/dev DataONE login
2. Uses the right prod/dev JWT
3. Lets the backend know whether it's prod/dev

The biggest UI change is that the user is prompted to login to DataONE _after_ they select a repository. The reason for this is that dev and production dataone uses two different login servers (and we need to know which one to send the user to).
To Test:
See [this issue](https://github.com/whole-tale/gwvolman/pull/72)

Note: I accidentally published a few Tales to production using this, so be careful when playing with the repository dropdown.