### PR TITLE
Check for content in publishInfo in Tale search filter

### DIFF
--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -113,7 +113,7 @@ export default Component.extend({
       this.set('filteredSet', models.filter(m => m.get('creatorId') === userId));
     } else if (filter === 'Published') {
       this.set('filteredSet', models.filter(m => {
-        return m.get('published') === true;
+        return m.get('publishInfo').length;
       }));
     } else if (filter === 'Recent') {
       const recentTales = this.get('internalState').getRecentTales();


### PR DESCRIPTION
This PR replaces the old check to see if a Tale has been published. Attached to issue #475 


To Test

1. Check this branch out
2. Create two Tales
3. Publish one
4. Navigate to Browse
5. Filter by published
6. You should only see your published Tale