### PR TITLE
Fix Compute Environments panel styling on Manage/Compose views

### DIFF
--- a/app/components/ui/compute-environments/template.hbs
+++ b/app/components/ui/compute-environments/template.hbs
@@ -30,8 +30,8 @@
             <div class="ui vertical menu fluid tales">
                 <a class="item {{if (eq model.id selectedEnvironment.id) 'active-class'}}" {{action 'selectEnvironment' model index}}>
                     <img src="{{model.icon}}" />
-                    <i class="fas fa-info blue" {{action 'openDetailsModal' model bubbles=false}}></i>
-                    <p>{{model.name}}</p>
+                    <i class="fas fa-info right floated blue icon" {{action 'openDetailsModal' model bubbles=false}}></i>
+                    <p class="environment-label">{{model.name}}</p>
                 </a>
             </div>
         {{/each}}

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -1300,3 +1300,7 @@ wt.panel .wt.paddleboard.header i {
 .tale-instances-item {
   height: 56px;
 }
+
+.environment-label {
+  margin-left: 75px !important;
+}


### PR DESCRIPTION
### Problem
Wonky styling on the Compose view's `compute-environment` panel has overlapping text, icons, and tooltip button:
![Screen Shot 2019-05-14 at 12 37 10 PM](https://user-images.githubusercontent.com/1413653/57719947-6ec98680-7646-11e9-8152-1976d51ae983.png)

This is a blocker for releasing v0.7

### Approach
Fix styling with some minor CSS tweaks:
![Screen Shot 2019-05-14 at 12 45 24 PM](https://user-images.githubusercontent.com/1413653/57719965-79841b80-7646-11e9-9b9a-d56e9134f3ae.png)

### How to Test
1. Checkout and run this branch locally
2. Login to the WholeTale Dashboard
3. Navigate to the Compose or Manage view
    * You should see the corrected styles applied in the `compute-environments` panel on the right
