### PR TITLE
Fix Overflowing Datasets. Fixes #468

### DIFF
--- a/app/components/ui/select-data-modal/template.hbs
+++ b/app/components/ui/select-data-modal/template.hbs
@@ -76,7 +76,7 @@
                 </div>
             </div>
             <div class="seven wide column">
-                <div class="ui segment">
+                <div class="ui segment" style="overflow-y:scroll;max-height:600px;">
                     <button class="ui very basic labeled icon button" {{action 'removeSelectedData'}}>
                         <i class="angle double left icon"></i>Remove Selected</button>
                     <table class="ui very basic compact striped fixed single line table">


### PR DESCRIPTION
Fix for issue #468 

The right column was missing the styling the the left column has, seen [here](https://github.com/whole-tale/dashboard/blob/master/app/components/ui/select-data-modal/template.hbs#L21)

Testing Steps: 
See attached issue; the table should no longer overflow.