### PR TITLE
Fix promise chaining to navigate after importing a Tale

### DIFF
--- a/app/components/dashboard/compose/left-panel/component.js
+++ b/app/components/dashboard/compose/left-panel/component.js
@@ -86,7 +86,7 @@ export default Component.extend({
 
   /**
    * Resets the GUI.
-   * @method getFinalJobStatus
+   * @method setDefaults
    */
   setDefaults() {
     // Set default values of mutable variables
@@ -227,6 +227,10 @@ export default Component.extend({
 
                 component.get('router').transitionTo('run.view', instanceId);
               }
+            },
+            err => {
+                component.set('errorMessage', err);
+                component.send('openErrorModal');
             });
         }, 1000);
       };
@@ -276,12 +280,13 @@ export default Component.extend({
 
                 /* Get the ID of the instance by getting the job status and then
                 transition to the run page, using the ID. */
-                component.get('apiCall').getFinalJobStatus(jobId,
+                component.get('apiCall').getFinalJobStatus(jobId).then(
                     function(res) {
                         component.get('router').transitionTo('run.view', res.instance._id);
                     },
                     function() {
                         component.set('errorMessage', self.get('defaultErrorMessage'));
+                        component.send('openErrorModal');
                     }
                 );   
             }
@@ -296,13 +301,14 @@ export default Component.extend({
             }
             else {
               // The job was canceled or resulted in an error
-              component.get('apiCall').getFinalJobStatus(jobId,
+              component.get('apiCall').getFinalJobStatus(jobId).then(
                 function(res) {
                   component.set('errorMessage', res);
                   component.send('openErrorModal');
                 },
-              function() {
+                function() {
                   component.set('errorMessage', self.get('defaultErrorMessage'));
+                  component.send('openErrorModal');
                 });
 
               // Stop querying the job endpoint
@@ -313,7 +319,7 @@ export default Component.extend({
     };
     //Start polling
     jobUpdateLoop = startLooping();
-},
+  },
 
   /**
    * Handles asking the backend to spawn a new tale import job.


### PR DESCRIPTION
### Problem
After the refactoring the publish modal, I apparently changed a method signature in the `api-call` service that is used by the "Import Tale" case. The method was changed to return a `Promise`, where it previously accepted `onSuccess`/`onFail` as parameters. In doing so, I missed changing the other call to `getFinalJobStatus` to use promise chaining.

Fixes #471

### Approach
Chain `onSuccess` / `onFail` to the return value instead of passing them as parameters - this allows us to more explicitly handle complex asynchronous interactions in the correct order.

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate directly to https://girder.local.wholetale.org/api/v1/integration/dataverse?fileId=3323458&siteUrl=https%3A%2F%2Fdataverse.harvard.edu
    * You should be brought to the Dashboard's "Compose" view
4. Choose an environment on the right side, then click "Launch New Tale"
5. Wait for your Tale to launch (watch `docker logs -f celery_worker` and wait for the `import_tale` task to complete)
    * You should be automatically brought to the Run view after your Imported Tale has launched
6. Launch a second Tale if you haven't already
7. With 2 Tales already running, repeat steps 3-5
    * Shortly after submitting, you should receive an error modal popup
    * You should see the following error in the modal: `Unable to create instance. Server returned 400: You have reached a limit for running instances (2). Please shutdown one of the running instances before continuing.`