### PR TITLE
Further improvements to Notification Stream UX

### DIFF
--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -44,7 +44,7 @@ export default Component.extend({
         const event = self.get('selectedEvent');
         self.get('store').findRecord('job', event.json.data.resource.jobs[0]).then(job => {
             if (job && job.log) {
-                self.set('selectedEventLogs', job.log.join('\n'));
+                self.set('selectedEventLogs', job.log.join(''));
             }
         });
     },

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -59,6 +59,11 @@ export default Component.extend({
     },
     
     actions: {
+        hideMessage(event) {
+            const self = this;
+            self.get('notificationStream').hideMessage(event);
+        },
+        
         markAllAsRead() {
             const self = this;
             self.get('notificationStream').markAllAsRead();

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -42,8 +42,10 @@ export default Component.extend({
         const self = this;
 
         const event = self.get('selectedEvent');
-        self.get('store').findRecord('job', event.json.data.imageInfo.jobId).then(job => {
-            self.set('selectedEventLogs', job.log);
+        self.get('store').findRecord('job', event.json.data.resource.jobs[0]).then(job => {
+            if (job && job.log) {
+                self.set('selectedEventLogs', job.log.join('\n'));
+            }
         });
     },
     

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -1,106 +1,67 @@
 {{#if notificationStream.showNotificationStream}}
-  <div class="ui feed computer tablet only" id="event-notification-stream">
-      
-    <button class="ui button fluid" id="ack-all-events-button" {{action 'markAllAsRead'}}>Mark All as Read</button>
-    
+
+
+  <div id="event-notification-stream">
+    <h3 id="event-stream-header" class="ui header">Current Tasks</h3>
     {{#if (eq notificationStream.events.length 0)}}
       <div id="event-notification-placeholder" class="placeholder message">
         <i class="huge check circle icon"></i>
         <p>No new events</p>
       </div>
     {{else}}
-      {{#each notificationStream.events as |event index|}}
-        {{!-- Ignore everything but build events --}}
-        {{#if (eq event.json.type 'wt_image_build_status')}}
-          {{#if (gt index 0)}}<hr />{{/if}}
-          <div class="event">
-            <div class="label">
-              {{#if (eq event.json.data.imageInfo.status 0)}}
-                <i class="event-icon huge warning icon"></i>
-              {{else if (eq event.json.data.imageInfo.status 1)}}
-                <i class="event-icon huge ban icon"></i>
-              {{else if (eq event.json.data.imageInfo.status 2)}}
-                <i class="event-icon huge cog loading icon"></i>
-              {{else if (eq event.json.data.imageInfo.status 3)}}
-                <i class="event-icon huge check icon"></i>
-              {{/if}}
-            </div>
-            <div class="content">
-              <div class="summary">
-                {{!-- TODO: Link to "/run/:tale_id" view once that is finished --}}
-                {{!-- {{event.json.data._id}} --}}
-                <a class="user" {{action 'gotoTale' event.json.data._id}}>
-                  {{truncate-name event.json.data.title}}
-                </a>
-                <br>
-                <div>
-                  {{#if (eq event.json.data.imageInfo.status 0)}}
-                    Tale image is invalid.
-                  {{else if (eq event.json.data.imageInfo.status 1)}}
-                    Tale image is unavailable.
-                  {{else if (eq event.json.data.imageInfo.status 2)}}
-                    Building tale image...
-                  {{else if (eq event.json.data.imageInfo.status 3)}}
-                    Tale image built successfully!
-                  {{/if}}
-                </div>
-                <div class="date">
-                  {{event.created}}
-                </div>
-              </div>
-              <div class="ui grid">
-                <div class="six wide column">
-                  <div class="meta">
-                    <a class="status" {{action 'openLogViewerModal' event}}>
-                      View Logs
-                    </a>
-                  </div>
-                </div>
-                <div class="ten wide column">
-                  <div class="meta">
-                    {{#if (eq event.json.data.imageInfo.status 3)}}
-                      <a class="logs" {{action 'restartTaleInstance' event.json.data}}>
-                        Restart to Use New Image
-                      </a>
-                    {{/if}}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        {{else if (eq event.json.type 'wt_error_backend_generic')}}
-        
-        {{!-- NOTE: This is currently unused --}}
-          <div class="event">
-            <div class="label">
-              <i class="fas fa-2x fa-fw fa-ban event-icon"></i>
-            </div>
-            <div class="content">
-              <div class="summary">
-                <a class="ui red label">ERROR</a> An error was encountered.
-                <div class="date">
-                  {{event.created}}
-                </div>
-                <div class="meta">
-                  {{#if DEBUG}}
-                    {{#if event.json.data.message}}
-                      {{event.json.data.message}}
-                    {{else}}
-                      {{event.json.data}}
-                    {{/if}}
+      <table class="ui small striped compact single line table nomargin">
+        {{#each notificationStream.events as |event index|}}
+          {{#unless event.hidden}}
+            {{#if (eq event.json.type 'wt_progress')}}
+              <tr class="{{if (eq event.json.data.state 'active') 'active'}}" title="Last update: {{event.updated}}">
+                <td width="30%">{{event.json.data.title}}</td>
+                <td width="60%">
+                  {{#if (eq event.json.data.state 'active')}}
+                    <div class="ui tiny indicating progress event-progress nomargin">
+                      {{#ui-progress progress=event.json.data.current value=event.json.data.current
+                          total=event.json.data.total class="teal indicating tiny"}}
+                        <div class="bar nomargin"></div>
+                        <div class="label">
+                          <i class="ui fas fa-fw fa-cog fa-spin icon"></i>
+                          {{event.json.data.message}}
+                        </div>
+                      {{/ui-progress}}
+                    </div>
+                  {{else if (eq event.json.data.state 'success')}}
+                    <i class="ui fas fa-fw fa-check-circle green icon"></i> Success
                   {{else}}
-                     Please report this error to an administrator.
-                     {{#if event.json.data.code}}
-                       Error code: {{event.json.data.code}}
-                     {{/if}}
+                    <i class="ui fas fa-fw fa-ban red icon"></i> Error{{#if event.json.data.message}}: {{event.json.data.message}}{{/if}}
                   {{/if}}
-                </div>
-              </div>
-            </div>
-          </div>
-        {{/if}}
-      {{/each}}
+                </td>
+                <td width="10%">
+                  {{#if (eq event.json.data.state 'active')}}
+                    <button class="ui tiny primary basic right floated button">
+                      Cancel
+                    </button>
+                  {{else}}
+                    <div class="ui tiny basic icon right floated buttons">
+                      <button class="ui tiny secondary basic right floated button">
+                        <i class="ui fas fa-fw fa-ellipsis-v icon"></i>
+                      </button>
+                    </div>
+                  {{/if}}
+                </td>
+              </tr>
+              
+            {{/if}}
+          {{/unless}}
+        {{/each}}
+      </table>
     {{/if}}
+    
+    <div class="ui grid nomargin" id="notification-stream-button-bar">
+      <div class="eight wide column">
+        <button class="ui basic primary fluid button" id="view-past-events-button" {{action 'viewPastEvents'}}>Past Tasks</button>
+      </div>
+      <div class="eight wide column">
+        <button class="ui basic secondary fluid button" id="ack-all-events-button" {{action 'markAllAsRead'}}>Mark All as Read</button>
+      </div>
+    </div>
   </div>
     
   <div id="log-viewer-modal" class="ui modal">
@@ -130,4 +91,5 @@
       <div class="ui button" {{action 'closeLogViewerModal'}}>Done</div>
     </div>
   </div>
+
 {{/if}}

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -14,7 +14,7 @@
           {{#unless event.hidden}}
             {{#if (eq event.json.type 'wt_progress')}}
               <tr class="{{if (eq event.json.data.state 'active') 'active'}}" title="Last update: {{event.updated}}">
-                <td width="30%">{{event.json.data.title}}</td>
+                <td width="30%"><label class="ui label">{{event.json.data.title}}</label></td>
                 <td width="60%">
                   {{#if (eq event.json.data.state 'active')}}
                     <div class="ui tiny indicating progress event-progress nomargin">
@@ -34,17 +34,15 @@
                   {{/if}}
                 </td>
                 <td width="10%">
-                  {{#if (eq event.json.data.state 'active')}}
-                    <button class="ui tiny primary basic right floated button">
-                      Cancel
+                    <button {{action 'openLogViewerModal' event}} class="ui tiny primary basic right floated button">
+                      View Logs
                     </button>
-                  {{else}}
+                  {{!--{{else}}
                     <div class="ui tiny basic icon right floated buttons">
                       <button class="ui tiny secondary basic right floated button">
                         <i class="ui fas fa-fw fa-ellipsis-v icon"></i>
                       </button>
-                    </div>
-                  {{/if}}
+                    </div>--}}
                 </td>
               </tr>
               
@@ -55,10 +53,10 @@
     {{/if}}
     
     <div class="ui grid nomargin" id="notification-stream-button-bar">
-      <div class="eight wide column">
+      {{!--<div class="eight wide column">
         <button class="ui basic primary fluid button" id="view-past-events-button" {{action 'viewPastEvents'}}>Past Tasks</button>
-      </div>
-      <div class="eight wide column">
+      </div>--}}
+      <div class="sixteen wide column">
         <button class="ui basic secondary fluid button" id="ack-all-events-button" {{action 'markAllAsRead'}}>Mark All as Read</button>
       </div>
     </div>

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -14,8 +14,9 @@
           {{#unless event.hidden}}
             {{#if (eq event.json.type 'wt_progress')}}
               <tr class="{{if (eq event.json.data.state 'active') 'active'}}" title="Last update: {{event.updated}}">
-                <td width="30%"><label class="ui label">{{event.json.data.title}}</label></td>
-                <td width="60%">
+                <td width="20%"><label class="ui label">{{event.json.data.title}}</label></td>
+                <td width="30%">{{truncate-name event.json.data.resource.tale.title}}</td>
+                <td width="40%">
                   {{#if (eq event.json.data.state 'active')}}
                     <div class="ui tiny indicating progress event-progress nomargin">
                       {{#ui-progress progress=event.json.data.current value=event.json.data.current
@@ -37,7 +38,7 @@
                     <button {{action 'openLogViewerModal' event}} class="ui tiny primary basic right floated button">
                       View Logs
                     </button>
-                  {{!--{{else}}
+                  {{!--
                     <div class="ui tiny basic icon right floated buttons">
                       <button class="ui tiny secondary basic right floated button">
                         <i class="ui fas fa-fw fa-ellipsis-v icon"></i>

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -5,7 +5,7 @@ export default DS.Model.extend({
   _modelType: DS.attr('string'),
   created: DS.attr('date'),
   interval: DS.attr('number'),
-  log: DS.attr('string'),
+  log: DS.attr(),
   parentId: DS.attr('string'),
   progress: DS.attr(),
   public: DS.attr('boolean'),

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -1263,27 +1263,40 @@ wt.panel .wt.paddleboard.header i {
 #event-notification-stream {
   position: fixed;
   top: 32px;
-  left: 70vw;
-  width: 26vw;
+  left: 55vw;
+  width: 40vw;
   background: #fff;
   box-shadow: 0 0 4px rgba(0,0,0,.2);
   border: 1px solid rgba(0,0,0,.2);
-  border-radius: 1rem;
-  padding-bottom: 15px;
+  border-radius: 0;
   max-height: 40vh;
   overflow-y: auto;
+}
+.event-meta {
+  padding-right:20px !important;
+  width:100% !important;
+}
+.event-stream-date {
+  float:right !important;
+  padding-right:20px !important;
+}
+#event-stream-header {
+  padding: 6px;
+}
+.nomargin {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+.event-progress >.label {
+  margin-top: 0;
+  width: unset;
 }
 #event-notification-stream > .event > .content > .summary {
   margin-left: 8px;
   font-weight: 400;
 }
-#ack-all-events-button {
-  border-radius: 1rem 1rem 0 0;
-}
-.event-icon {
-  padding:0 !important;
-  margin: 9px 12px !important;
-  font-size: 2.5em !important;
+#notification-stream > button {
+  border-radius: 0;
 }
 
 #instance-deleting-loader {

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -1263,8 +1263,8 @@ wt.panel .wt.paddleboard.header i {
 #event-notification-stream {
   position: fixed;
   top: 32px;
-  left: 55vw;
-  width: 40vw;
+  left: 40vw;
+  width: 55vw;
   background: #fff;
   box-shadow: 0 0 4px rgba(0,0,0,.2);
   border: 1px solid rgba(0,0,0,.2);

--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -55,7 +55,7 @@
             </a>
             <a class="item wt thin not-nav" target="_blank" {{action 'toggleShowNotifications'}}
               href="#" data-tooltip="Show or hide server notifications." data-position="bottom right">
-                <i class="exclamation circle white large icon"></i>
+                <i class="tasks white large icon"></i>
                 {{#if (gt notificationStream.events.length 0)}}
                     <div id="event-notification-counter" class="floating ui red label">
                         {{ notificationStream.events.length }}
@@ -109,7 +109,7 @@
                         </li>
                         <li class="bm-menu-item">
                             <a target="_blank" {{action 'toggleShowNotifications'}}>
-                                <i class="info circle black icon"></i> {{if showNotificationStream 'Hide' 'Show'}} Notifications
+                                <i class="tasks black icon"></i> {{if showNotificationStream 'Hide' 'Show'}} Notifications
                             </a>
                         </li>
                         <li class="bm-menu-item">


### PR DESCRIPTION
### Problem
A single event can cause multiple status changes - each of these appears in the UI as a separate event. This can be confusing to users, who will see a spinning "Tale building" event followed by a "Build complete", although it may not be clear that these are referencing the same operation.

### Approach
Update prior events when we are able, instead of creating a new array item. This way, the user sees a "Tale building" notification at first. Once the build is complete, this notification is replaced in the view with a "Success" event. This makes it much more clear that the operation has actually completed.

NOTE: Restyling work has been cut short to facilitate a demo/workshop next week. Work can resume on the restyling of the `notification-stream` component once the task progress updates have been merged

Furthermore, this can serve as an example pattern for how we can use the event's payload to multiplex on behavior:
* if a received notification shares an `_id` with an already-displayed event, we should update the displayed event in the event list
* if a received notification has a unique `_id`, append to the event list

#### Cases Covered / Demonstrations
NOTE: these GIFs are already slightly out-of-date

* Create instance: http://recordit.co/XL28fTOoBm
* Building image: http://recordit.co/rhyLSmfQzP
* Updating instance: http://recordit.co/MY1vYRyQQ1

### How to Test
Prerequisites: running [`girder_wholetale` notification-poc branch](https://github.com/whole-tale/girder_wholetale/pull/305) and [`gwvolman` notification-poc branch](https://github.com/whole-tale/gwvolman/pull/75)

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch any Tale, but **DO NOT** dismiss the notification.
    * You should see a "Creating instance" notification pop up
    * You should only see one of these notifications at a time (per request)
    * Once the launch is complete, your notification should update in the display to a "Success" notification
5. Once the Tale has launched, navigate to the Run view for your Tale by selecting it on the right
6. Expand the dropdown at the top-right of the left pane and select "Rebuild Tale"
    * You should see a "Building image" notification pop up
    * You should only see one of these notifications at a time (per request)
    * Once the build is complete, your notification should update in the display to a "Success" notification
6. Finally, expand the dropdown at the top-right of the left pane and select "Restart Tale"
    * You should see an "Updating instance" notification pop up
    * You should only see one of these notifications at a time (per request)
    * Once the restart is complete, your notification should update in the display to a "Success" notification
    