### PR TITLE
Fix blue screen when folders are deleted

### DIFF
--- a/app/routes/manage/index.js
+++ b/app/routes/manage/index.js
@@ -44,7 +44,6 @@ export default AuthenticateRoute.extend({
 
     var folderContents = {};
     var itemContents = Deferred();
-
     if (!folderID || folderID === "null") {
       let nav = this.get('folderNavs').getFolderNavFor('home');
       folderContents = this.get('store').query('folder', {
@@ -83,7 +82,6 @@ export default AuthenticateRoute.extend({
         }
       });
     } else {
-      console.log("Folder != null, so loading folder and items");
       folderContents = this.get('store').query('folder', {
         parentId: folderID,
         parentType: 'folder',
@@ -93,6 +91,9 @@ export default AuthenticateRoute.extend({
             limit: "0"
           }
         }
+      }).catch((err) => {
+        console.log('Failed to get folder', err);
+        return;
       });
       itemContents.resolve(this.get('store').query('item', {
         folderId: folderID,
@@ -102,8 +103,10 @@ export default AuthenticateRoute.extend({
             limit: "0"
           }
         }
-      }));
-      console.log("Folder != null, leaving");
+      }).catch((err) => {
+        console.log('Failed to get items', err);
+        return;
+      }))
     }
     return RSVP.hash({
       folderContents: folderContents,


### PR DESCRIPTION
This is a small addition to the checks we have against bad internal state as a fix for issue #472.

The cause was that I had a valid currentFolderID (ie it wasn't null or undefined), but it was referencing a deleted folder. This was causing the screen to render blue when the request would fail.

Testing steps can be found under the first test under `Regression Tests` at the bottom of the [testing docs](https://github.com/whole-tale/wt-design-docs/blob/master/ISSUE_TEMPLATE/test_plan.md)