### PR TITLE
Properly close notification stream on errors

### DIFF
--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -43,7 +43,7 @@ export default Service.extend({
         newSource.onerror = (err) => {
             (console && console.error && console.error("EventSource failed:", err))
                 || console.log("EventSource failed:", err);
-            self.get('notificationStream').close();
+            self.close();
         };  
         
         self.set('source', newSource);


### PR DESCRIPTION
AFAIU `self` **is** the `notificationStream` inside `newSource.onerror`. This change fixes the nasty traceback we've been seeing every few minutes and notifications don't seem to reappear.

To test:
1. Login to dashboard in incognito mode.
2. Create a Tale, wait for it to finish.
3. Mark notifications as read.
4. Wait to see if they reappear (might want to grab a lunch, cause they shouldn't ;) )
5. (optionally) do 1.-4. on current master.