### PR TITLE
Close the notification panel / stream on logout

### DIFF
--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -69,7 +69,7 @@ export default Service.extend({
     close() {
         const self = this;
         const source = self.get('source');
-        if (source != null && source.readyState == EventSource.CLOSED) {
+        if (source != null && source.readyState != EventSource.CLOSED) {
             DEBUG && VERBOSE && console.log('Closing connection...');
             source.close();
         }

--- a/app/services/user-auth.js
+++ b/app/services/user-auth.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 
 export default Service.extend({
   tokenHandler: service('token-handler'),
+  notificationStream: service('notification-stream'),
   store: service(),
   authRequest: service(),
 
@@ -61,6 +62,8 @@ export default Service.extend({
         // console.log(e);
       })
       .finally(() => {
+        self.get('notificationStream').set('showNotificationStream', false);
+        self.get('notificationStream').close();
         self.get('tokenHandler').releaseWholeTaleCookie();
         localStorage.currentUserID = null;
         localStorage.clear();


### PR DESCRIPTION
### Problem
If the notification panel/stream is open when the user logs out, then there is no option to close it. Furthermore since the user's auth token is invalidated on logout, no further events should/can come through the stream after this point.

Fixes #487 

### Approach
Close the EventStream resource and hide the panel when logging the user out.

NOTE: While following this test case you **will** see 401 errors coming from the instance poller , which continues to run after logout - this is the behavior described in #488, which is out-of-scope for this PR

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Platform
3. Launch a Tale
    * You should see the panel appear offering progress notifications
4. While the Tale is still launching, log out of the WholeTale Platform
    * You should see the notification panel has automatically disappeared
    * You should not see any errors from the `notification-stream` service in the console
    * IMPORTANT: You should not see any events come through after this point, until you log back in
    * Side-note: You will see the behavior described in #488 here as well (not addressed in this PR)
