### PR TITLE
Show the remove context option for writeable workspaces

### DIFF
--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -101,8 +101,9 @@
                                             {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
                                         {{else}}
                                             <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
-                                            <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                         {{/if}}
+                                        {{!-- Always show Download option for writeable Workspaces--}}
+                                        <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                     {{/if}}
                                     
                                     {{!-- Always show Download option --}}

--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -102,7 +102,7 @@
                                         {{else}}
                                             <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
                                         {{/if}}
-                                        {{!-- Always show Download option for writeable Workspaces--}}
+                                        {{!-- Always show the Remove option for writeable Workspaces--}}
                                         <a class="item" {{action "remove" item}}><i class="trash icon"></i> Remove</a>
                                     {{/if}}
                                     


### PR DESCRIPTION
This code change displays the `Remove` item in the drop down context menu for folders that are in the workspace & writeable (accesLevel >0). Fixes issue #486


### Testing Steps:
1. Checkout this branch
2. Launch a Tale
3. Navigate to the Tale's Workspace
4. Create a folder
5. Attempt to delete it
6. Navigate to Home
7. Make sure that you can still delete folders