### PR TITLE
Merge Fix - Remove the auth query param on page load

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -122,6 +122,7 @@ export default Component.extend(FullScreenMixin, {
           let queryParams = this.get('params')
           if (queryParams) {
             if (queryParams.auth === 'true') {
+              this.router.transitionTo({ queryParams: { auth: null }});
               this.get('store').findRecord('tale', this.model.taleId, {
                 reload: true
               })


### PR DESCRIPTION
Something went amuck when merging PR #467 and [this line](https://github.com/whole-tale/dashboard/blob/1b9492b6e87f0aa0f06331e1497794eab11535e5/app/components/dashboard/run/left-panel/component.js#L119) didn't make it into master.

Testing:
1. Navigate to the run page
2. Sign out of DataONE
3. Open the publish modal
4. Sign in
5. The dialog should open
6. Note auth=true in the URL is gone