### PR TITLE
Fix "Run" button in "Run" view during error state

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -380,6 +380,8 @@ export default Component.extend(FullScreenMixin, {
                             cancel(contingency);
                         }).catch((error) => {
                             self.set("taleLaunchError", error.message);
+                            self.set('disableStartStop', false);
+                            self.set('taleTransitioning', false);
                             console.log('Error waiting for Tale to start:', error);
                         }).finally(() => {
                             self.set('disableStartStop', false);
@@ -387,6 +389,8 @@ export default Component.extend(FullScreenMixin, {
                         });
                 }).catch((error) => {
                     self.set("taleLaunchError", error.message);
+                    self.set('disableStartStop', false);
+                    self.set('taleTransitioning', false);
                     console.log('Error starting tale:', error);
                 });
         },
@@ -411,7 +415,7 @@ export default Component.extend(FullScreenMixin, {
                 }).catch((error) => {
                     // deal with the failure here
                     self.set("error_msg", error.message);
-                    console.log('Error starting tale:', error);
+                    console.log('Error stopping tale:', error);
                     self.set('disableStartStop', false);
                     self.set('taleTransitioning', false);
                 });


### PR DESCRIPTION
### Problem
Fixes an issue reported by @Xarthisius while reviewing #459. The inner `.finally()` was not being called due to a failure in the outer promise.

### Approach
Reset `disableStartStop` and `taleTransitioning` when we encounter a failure.

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Platform
3. Navigate to Browse and launch as many Tales as possible
    * You should start seeing the "too many instances" errors appear
4. Hover over a stopped Tale and click "View"
    * You should be taken to the Run view for the chosen Tale
5. At the top-right, click the "Run" button
    * You should see an error message appear on the Interact tab
    * You should see the run button change to its error state - an exclamation icon and the word "Run" on a clickable button
    * You should NOT see an infinite spinner on the "Run" button
    * NOTE: Styling in this case can be adjusted to make the button red or something more prominent, if desired