### PR TITLE
[WIP ] Improve notification stream styling, show past events

### DIFF
--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -2,7 +2,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
-import EmberObject, { computed } from '@ember/object';
+import EmberObject from '@ember/object';
 import config from '../../../config/environment';
 import $ from 'jquery';
 import layout from './template';
@@ -61,6 +61,14 @@ export default Component.extend({
     },
     
     actions: {
+        toggleShowNotifications() {
+            this.notificationStream.toggleShowNotifications();
+        },
+        
+        togglePastEvents() {
+            this.notificationStream.togglePastEvents();
+        },
+    
         hideMessage(event) {
             const self = this;
             self.get('notificationStream').hideMessage(event);

--- a/app/components/ui/notification-stream/component.js
+++ b/app/components/ui/notification-stream/component.js
@@ -42,7 +42,7 @@ export default Component.extend({
         const self = this;
 
         const event = self.get('selectedEvent');
-        self.get('store').findRecord('job', event.json.data.resource.jobs[0]).then(job => {
+        self.get('store').findRecord('job', event.data.resource.jobs[0]).then(job => {
             if (job && job.log) {
                 self.set('selectedEventLogs', job.log.join(''));
             }

--- a/app/components/ui/notification-stream/template.hbs
+++ b/app/components/ui/notification-stream/template.hbs
@@ -2,42 +2,55 @@
 
 
   <div id="event-notification-stream">
-    <h3 id="event-stream-header" class="ui header">Current Tasks</h3>
-    {{#if (eq notificationStream.events.length 0)}}
-      <div id="event-notification-placeholder" class="placeholder message">
-        <i class="huge check circle icon"></i>
-        <p>No new events</p>
+    <div class="ui grid">
+      <div class="fifteen wide column">
+        <h3 id="event-stream-header" class="ui header">{{if notificationStream.showPastEvents 'All' 'Current'}} Tasks</h3>
       </div>
-    {{else}}
-      <table class="ui small striped compact single line table nomargin">
-        {{#each notificationStream.events as |event index|}}
-          {{#unless event.hidden}}
-            {{#if (eq event.json.type 'wt_progress')}}
-              <tr class="{{if (eq event.json.data.state 'active') 'active'}}" title="Last update: {{event.updated}}">
-                <td width="20%"><label class="ui label">{{event.json.data.title}}</label></td>
-                <td width="30%">{{truncate-name event.json.data.resource.tale.title}}</td>
+      <div class="one wide column">
+        <div class="ui tiny basic icon right floated buttons">
+          <button class="ui basic tiny right floated icon button" {{action 'toggleShowNotifications'}}>
+            <i class="fas fa-times fa-fw icon"></i>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div id="event-notification-scroller">
+      {{#if (eq notificationStream.allEvents.length 0)}}
+        <div id="event-notification-placeholder" class="placeholder message">
+          <i class="huge check circle icon"></i>
+          <p>No tasks have been run</p>
+        </div>
+      {{else}}
+        <table class="ui small striped compact single line table nomargin">
+          {{#each notificationStream.allEvents as |event index|}}
+            {{#if (eq event.type 'wt_progress')}}
+              <tr class="{{if (eq event.data.state 'active') 'active'}}" title="Last update: {{event.updated}}">
+                <td width="20%"><label class="ui label">{{event.data.title}}</label></td>
+                <td width="30%">{{truncate-name event.data.resource.tale.title}}</td>
                 <td width="40%">
-                  {{#if (eq event.json.data.state 'active')}}
+                  {{#if (eq event.data.state 'active')}}
                     <div class="ui tiny indicating progress event-progress nomargin">
-                      {{#ui-progress progress=event.json.data.current value=event.json.data.current
-                          total=event.json.data.total class="teal indicating tiny"}}
+                      {{#ui-progress progress=event.data.current value=event.data.current
+                          total=event.data.total class="teal indicating tiny"}}
                         <div class="bar nomargin"></div>
                         <div class="label">
                           <i class="ui fas fa-fw fa-cog fa-spin icon"></i>
-                          {{event.json.data.message}}
+                          {{event.data.message}}
                         </div>
                       {{/ui-progress}}
                     </div>
-                  {{else if (eq event.json.data.state 'success')}}
+                  {{else if (eq event.data.state 'success')}}
                     <i class="ui fas fa-fw fa-check-circle green icon"></i> Success
                   {{else}}
-                    <i class="ui fas fa-fw fa-ban red icon"></i> Error{{#if event.json.data.message}}: {{event.json.data.message}}{{/if}}
+                    <i class="ui fas fa-fw fa-ban red icon"></i> Error{{#if event.data.message}}: {{event.data.message}}{{/if}}
                   {{/if}}
                 </td>
                 <td width="10%">
+                  {{#if event.data.resource.jobs.length}}
                     <button {{action 'openLogViewerModal' event}} class="ui tiny primary basic right floated button">
                       View Logs
                     </button>
+                  {{/if}}
                   {{!--
                     <div class="ui tiny basic icon right floated buttons">
                       <button class="ui tiny secondary basic right floated button">
@@ -48,17 +61,22 @@
               </tr>
               
             {{/if}}
-          {{/unless}}
-        {{/each}}
-      </table>
-    {{/if}}
-    
+          {{/each}}
+          
+        </table>
+      {{/if}}
+    </div>
+      
     <div class="ui grid nomargin" id="notification-stream-button-bar">
-      {{!--<div class="eight wide column">
-        <button class="ui basic primary fluid button" id="view-past-events-button" {{action 'viewPastEvents'}}>Past Tasks</button>
-      </div>--}}
-      <div class="sixteen wide column">
-        <button class="ui basic secondary fluid button" id="ack-all-events-button" {{action 'markAllAsRead'}}>Mark All as Read</button>
+      <div class="eight wide column">
+        <button class="ui basic primary fluid button" id="view-past-events-button" {{action 'togglePastEvents'}}>
+          Show {{if notificationStream.showPastEvents 'Only Unread' 'All'}} Tasks
+        </button>
+      </div>
+      <div class="eight wide column">
+        <button class="ui basic secondary fluid button" id="ack-all-events-button" {{action 'markAllAsRead'}}>
+          Mark All as Read
+        </button>
       </div>
     </div>
   </div>

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -125,8 +125,7 @@ export default Controller.extend({
       this.set('mobileMenuDisplay', displayMobileMenu);
     },
     toggleShowNotifications() {
-      this.notificationStream.set('showNotificationStream', 
-        !this.notificationStream.showNotificationStream); 
+      this.notificationStream.toggleShowNotifications();
     },
   }
 

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -426,8 +426,23 @@ export default Service.extend({
           client.send();
       });
     },
+    
+    getPastNotifications(sinceMs) {
+        const since = new Date(sinceMs).toISOString();
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                url: `${config.apiUrl}/notification?since=${since}`,
+                headers: {
+                    'Girder-Token': this.get('tokenHandler').getWholeTaleAuthToken()
+                },
+                timeout: 3000,
+                success: resolve,
+                error: reject
+            });
+        });
+    },
 
-      /**
+    /**
      * Returns the workspace folder ID for a Tale
      * @method getWorkspaceId
      * @param taleId The ID of the Tale

--- a/app/services/notification-stream.js
+++ b/app/services/notification-stream.js
@@ -140,31 +140,27 @@ export default Service.extend({
     
     
     attachTaleData(event) {
-        const self = this;
-        
-        // NOTE: there is a difference in format between the two endpoints
-        // /notification and /notification/stream return different formats    
-        let evt = event || event;
+        const self = this;  
         
         // Short-circuit if this event does not contain a resource
-        if (!evt.data.resource) {
+        if (!event.data.resource) {
             return;
         }
         
         // Attempt to use instanceId/taleId to attach the tale to its related event
-        const taleId = evt.data.resource.tale_id;
-        const instanceId = evt.data.resource.instance_id;
+        const taleId = event.data.resource.tale_id;
+        const instanceId = event.data.resource.instance_id;
         if (taleId) {
-            evt.data.resource.tale = self.store.peekRecord('tale', taleId);
+            event.data.resource.tale = self.store.peekRecord('tale', taleId);
         } else if (instanceId) { 
             // XXX: this branch shouldn't be necessary, "restart tale" should send us tale_id as well
             const instance = self.store.peekRecord('instance', instanceId);
             if (instance) {
-                evt.data.resource.tale = self.store.peekRecord('tale', instance.taleId);
+                event.data.resource.tale = self.store.peekRecord('tale', instance.taleId);
             } else {
-                evt.data.resource.tale = { title: 'ERROR: Tale not found' }
+                event.data.resource.tale = { title: 'ERROR: Tale not found' }
                 self.store.findRecord('instance', instanceId).then(instance => {
-                    evt.data.resource.tale = self.store.peekRecord('tale', instance.taleId);
+                    event.data.resource.tale = self.store.peekRecord('tale', instance.taleId);
                 });
             }
         } else {
@@ -179,8 +175,6 @@ export default Service.extend({
         
         // Parse event data (tale) into JSON
         event = JSON.parse(event.data);
-        //event.created = new Date(event.time).toLocaleString();
-        //event.updated = new Date(event.updated).toLocaleString();
         
         // Push new event data
         const events = self.get('events');
@@ -215,13 +209,6 @@ export default Service.extend({
             }
             self.set('events', events);
             self.set('showNotificationStream', true);
-        } else if (event.data.message) {
-            // Handle displaying progress updates for tasks
-        } else if (event.data.text) {
-            // Handle build log updates
-            // FIXME: Why are these sent as notifications? 
-            // FIXME: These logs are not displayed in the UI, and are currently fetched on demand when requested
-            //console.log(`Notification (${event._id}): Log update encountered: ${event.data.text}`, event);
         } else {
             //console.log(`Ignored notification (${event._id}): Job event (${event.data._id}) encountered: ${event.data.title} -> ${event.data.status}`, event);
         }

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -1258,18 +1258,20 @@ wt.panel .wt.paddleboard.header i {
   text-align: center;
 }
 #event-notification-placeholder {
-  margin-top: 40px;
+  padding-top: 40px;
 }
 #event-notification-stream {
   position: fixed;
-  top: 32px;
-  left: 40vw;
+  top: 48px;
+  left: 38vw;
   width: 55vw;
   background: #fff;
   box-shadow: 0 0 4px rgba(0,0,0,.2);
   border: 1px solid rgba(0,0,0,.2);
   border-radius: 0;
-  max-height: 40vh;
+}
+#event-notification-scroller {
+  height: 40vh;
   overflow-y: auto;
 }
 .event-meta {


### PR DESCRIPTION
## TODOs
* Clean-up styling/wording - "past" / "current" meaning could be made more clear

### Problem
Once a user clears/acknowledges an event, there is no way to see it again. This excludes logging out, which currently resets the user's `lastRead` timestamp and shows all cleared notification once again.

### Approach
Add a toggle to display "Past Events" (name/title TBD).

### How to Test
TBD