### PR TITLE
Add 'My Tales' filter back to Browse view

### DIFF
--- a/app/components/ui/delete-modal/component.js
+++ b/app/components/ui/delete-modal/component.js
@@ -2,13 +2,8 @@ import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';
 
 export default Component.extend({
-  model: EmberObject.create({}),
+  modelName: "",
   classNameBindings: ['injectedClassName'],
-  
-  // Instance uses "name" everything else uses "title"
-  name: computed('model.name', 'model.title', function() {
-    return this.model.name || this.model.title;
-  }),
 
   injectedClassName: computed('modelType', 'model._modelType', 'model._id', function () {
     if(this.get('modelType')) {

--- a/app/components/ui/delete-modal/template.hbs
+++ b/app/components/ui/delete-modal/template.hbs
@@ -4,7 +4,7 @@
     </div>
     <div class="image content">
         <div class="description">
-            <p style="color: #000 !important;">This will permanently delete the '{{truncate-name name}}' {{modelType}}. Continue?</p>
+            <p style="color: #000 !important;">This will permanently delete the '{{truncate-name modelName}}' {{modelType}}. Continue?</p>
         </div>
     </div>
     <div class="actions">

--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -124,10 +124,12 @@ export default Component.extend({
       this.set('filteredSet', models);
     } else if (filter === 'Mine') {
       const userId = this.get('userAuth').getCurrentUserID();
-      this.set('filteredSet', models.filter(m => m.get('creatorId') === userId));
+      let m = models.filter(m => m.creatorId === userId);
+      console.log("Models: ", m);
+      this.set('filteredSet', m);
     } else if (filter === 'Published') {
       this.set('filteredSet', models.filter(m => {
-        return m.get('publishInfo').length;
+        return m.publishInfo.length;
       }));
     } else if (filter === 'Recent') {
       const recentTales = this.get('internalState').getRecentTales();
@@ -138,7 +140,7 @@ export default Component.extend({
       this.set('filteredSet', A());
     }
 
-    this.actions.searchFilter.call(this);
+    this.actions.searchFilter.call(this, filter);
     this.actions.toggleFiltersVisibility.call(this);
   },
 
@@ -193,13 +195,18 @@ export default Component.extend({
       this.set('filter', 'All');
       this.setFilter();
     },
-    searchFilter() {
+    selectFilter(filter) {
+      const component = this;
+      component.set('filter', filter);
+      this.setFilter();
+    },
+    searchFilter(filter) {
       let searchStr = this.get('searchStr');
-
+      
       const filteredSet = this.get("filteredSet");
       const component = this;
-
-      let promise = new Promise((resolve, reject) => {
+      
+      return new Promise((resolve, reject) => {
         let searchView = [];
         filteredSet.forEach(model => {
           if (model && model.id) {
@@ -211,9 +218,7 @@ export default Component.extend({
         });
         component.set('loadingTales', false);
         resolve(searchView);
-      });
-
-      promise.then((searchView) => {
+      }).then((searchView) => {
         component.set('searchView', searchView);
         component.set('modelsInView', searchView);
       });

--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -8,7 +8,6 @@ import $ from 'jquery';
 const O = EmberObject.create.bind(EmberObject);
 
 export default Component.extend({
-  currentTab: 'all',
   store: service(),
   userAuth: service('user-auth'),
   apiCall: service('api-call'),

--- a/app/components/ui/tale-browser/template.hbs
+++ b/app/components/ui/tale-browser/template.hbs
@@ -149,7 +149,7 @@
     
     {{#unless modelsInView.length}}
         <div class="ui center aligned segment" style="color: black;">
-            There are no tales to display for applied filter: {{currentTab}}
+            There are no tales to display for applied filter: {{filter}}
         </div>
     {{/unless}}
     {{#if loadingTales}}
@@ -186,7 +186,7 @@
                                                     <div class="content">
                                                         <div class="center">
                                                             {{#if showLink}}
-                                                                {{#link-to 'run.view' model._id class="ui inverted button"}}View{{/link-to}}
+                                                                {{#link-to 'run.view' model._id (query-params tab="metadata") class="ui inverted button"}}View{{/link-to}}
                                                             {{/if}}
                                                             {{#if showSelect}}
                                                                 <div class="ui inverted button" {{action 'select' model}}>Select</div>
@@ -279,7 +279,7 @@
                                 <div class="content">
                                     <div class="center">
                                         {{#if showLink}}
-                                            {{#link-to 'run.view' model._id class="ui inverted button"}}View{{/link-to}}
+                                            {{#link-to 'run.view' model._id (query-params tab="metadata") class="ui inverted button"}}View{{/link-to}}
                                         {{/if}}
                                         {{#if showSelect}}
                                             <div class="ui inverted button" {{action 'select' model}}>Select</div>
@@ -423,25 +423,4 @@
     </div>
 </div>
 
-<div id="copy-on-launch-modal" class="ui small modal">
-  <i class="close icon"></i>
-  <div class="header">
-    <i class="fas fa-exclamation-triangle icon"></i>
-    Insufficient Access
-  </div>
-  <div class="content">
-    <p>You do not have sufficient access to run this Tale, but you can create your own copy!</p>
-    <p></p>
-    <p>Create a copy of this Tale and run the copy now?</p>
-  </div>
-  <div class="actions">
-    <div class="ui black deny button" {{action 'closeCopyOnLaunchModal'}}>
-      <i class="remove icon"></i>
-      Cancel
-    </div>
-    <div class="ui positive right labeled icon button" {{action 'submitCopyAndLaunch' taleToCopy}}>
-      Copy and Run
-      <i class="checkmark icon"></i>
-    </div>
-  </div>
-</div>
+{{ui/copy-on-launch-modal taleToCopy=taleToCopy modelsInView=modelsInView}}

--- a/app/components/ui/tale-browser/template.hbs
+++ b/app/components/ui/tale-browser/template.hbs
@@ -128,11 +128,10 @@
     <div class="ui grid">
         <div class="twelve wide column" id="tale-filters">
             <div id="tale-filter-items" class="ui compact menu">
-                <a class="item clickable tale-filter-item {{if (eq currentTab 'all') 'active'}}" {{action 'selectFilter' 'all'}}>
+                <a class="item clickable tale-filter-item {{if (eq filter 'All') 'active'}}" {{action 'selectFilter' 'All'}}>
                     All Tales
                 </a>
-                {{!-- To enable tab:  {{action 'selectFilter' 'mine'}} --}}
-                <a class="item not clickable tale-filter-item {{if (eq currentTab 'mine') 'active'}}">
+                <a class="item clickable tale-filter-item {{if (eq filter 'Mine') 'active'}}" {{action 'selectFilter' 'Mine'}}>
                     My Tales
                 </a>
             </div>

--- a/app/components/ui/tale-browser/template.hbs
+++ b/app/components/ui/tale-browser/template.hbs
@@ -402,7 +402,7 @@
 </div>
 
 {{ui/delete-modal
-    model=selectedTale
+    modelName=selectedTale.title
     modelType="tale"
     approveDelete=(action "approveDelete" selectedTale)
     denyDelete=(action "denyDelete" selectedTale)}}

--- a/app/components/ui/tale-instances/template.hbs
+++ b/app/components/ui/tale-instances/template.hbs
@@ -64,7 +64,7 @@
 </div>
 
 {{ui/delete-modal 
-    model=selectedInstance 
+    modelName=selectedInstance.name
     modelType="instance" 
     approveDelete=(action "approveDelete" selectedInstance) 
     denyDelete=(action "denyDelete")}}


### PR DESCRIPTION
### Problem
After refactoring the Browse view, the "My Tales" filter has been disabled.

Fixes #511 

### Approach
Re-enable the "My Tales" filter.

NOTE: This PR does not alter the method by which the tales are searched or filtered.

### How to Test
Prerequisites: At least one Tale accessible not owned by you

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Browse view
    * By default, you should be shown "All Tales" (API automatically filters GET /tales to only those accessible to the current user)
4. On the top-left, click the "My Tales" filter button
    * You should see the contents of the view change to only show you items you have created
    * NOTE: this could be adjusted to filter on `_accessLevel`, if desired