### PR TITLE
Hide tabs/dropdown items that are unfinished/disabled in the Browse view

### DIFF
--- a/app/components/dashboard/browse/left-panel/template.hbs
+++ b/app/components/dashboard/browse/left-panel/template.hbs
@@ -50,13 +50,13 @@
        <img src="images/wholetale_logo_sm.png" /> Tales
   </div>
    {{!-- To enable tab: onclick={{action 'selectTab' 'data'}} --}}
-  <div class="not clickable item {{if (eq currentTab 'data') 'active'}}">
+  {{!-- <div class="not clickable item {{if (eq currentTab 'data') 'active'}}">
        <i class="fa fa-server"></i> Data Catalog
-  </div>
+  </div> --}}
   {{!-- To enable tab:  onclick={{action 'selectTab' 'environments'}} --}}
-  <div class="not clickable item {{if (eq currentTab 'environments') 'active'}}">
+  {{!--  <div class="not clickable item {{if (eq currentTab 'environments') 'active'}}">
        <i class="fa fa-desktop"></i> Compute Environments
-  </div>
+  </div> --}}
 </div>
 
 {{#if (eq currentTab 'tales')}}

--- a/app/components/dashboard/browse/left-panel/template.hbs
+++ b/app/components/dashboard/browse/left-panel/template.hbs
@@ -9,14 +9,14 @@
           <img class="ui avatar image" src="images/wholetale_logo_sm.png" style="height: 14px;width: 14px;vertical-align: middle;">
           Create New Tale
         </div>
-        <div class="item not clickable">
+        {{!--<div class="item not clickable">
           <i class="fas fa-server icon"></i>
           Add Dataset
         </div>
         <div class="item not clickable">
           <i class="fas fa-desktop icon"></i>
           Create New Environment
-        </div>
+        </div>--}}
       </div>
     </div>
     


### PR DESCRIPTION
### Problem
After refactoring the Browse view, the "Data Catalog" and "Compute Environment" tabs are unfinished and disabled. Releasing these tabs in such a state could cause users to become confused.

### Approach
Hide the unfinished tabs until their content has been completed.

### How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Browse view
    * You should only see the "Tales" tab along the top of the catalog
    * You should no longer see the "Data Catalog" or "Compute Environments" tabs