### PR TITLE
Copy on launch from run view

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -356,11 +356,21 @@ export default Component.extend(FullScreenMixin, {
         rebuildTale(taleId) {
             this.get('apiCall').rebuildTale(taleId);
         },
+    
+        openCopyOnLaunchModal(taleToCopy) {
+          const component = this;
+          $('#copy-on-launch-modal').modal('show');
+          component.set('taleToCopy', taleToCopy);
+        },
         
         startTale(tale) {
             const self = this;
             if (!tale) {
                 console.log('Invalid tale', tale);
+            } else if (tale._accessLevel < 1) {
+              // Prompt for confirmation before copying and launching
+              self.actions.openCopyOnLaunchModal.call(self, tale);
+              return;
             }
             
             // Disable "Start" button - re-enable after a delay?
@@ -498,7 +508,7 @@ export default Component.extend(FullScreenMixin, {
           }
 
             self.set('publishStatus', 'in_progress');
-            self.set('progress', 0);   
+            self.set('progress', 0);
             const tale = self.get('model');
 
             // Call the publish endpoint

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -8,7 +8,13 @@
                 <img class="illustration" src="{{model.illustration}}" />
                 <img class="env" src="{{model.icon}}" />
                 <div class="header name">
-                    <h3>{{truncate-name model.title}}</h3>
+                    <h3>
+                        {{#if model.copyOfTale}}
+                            <a class="ui tiny blue horizontal label">COPY</a>
+                        {{/if}}
+                        {{truncate-name model.title}}
+                    </h3>
+                    
                     <span>{{tale-authors-to-str model.authors model.creator}}</span>
                 </div>
             </div>
@@ -255,3 +261,6 @@
     </div>
   </div>
 </div>
+
+
+{{ui/copy-on-launch-modal taleToCopy=taleToCopy}}

--- a/app/components/ui/copy-on-launch-modal/component.js
+++ b/app/components/ui/copy-on-launch-modal/component.js
@@ -1,0 +1,101 @@
+import Component from '@ember/component';
+import EmberObject from '@ember/object';
+import { A } from '@ember/array';
+import { later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+import $ from 'jquery';
+import layout from './template';
+
+export default Component.extend({
+    layout,
+    store: service(),
+    apiCall: service('api-call'),
+    router: service(),
+    
+    taleToCopy: null,
+
+
+    actions: {
+        closeCopyOnLaunchModal() {
+            console.log("Cancelled.");
+          const component = this;
+          $('#copy-on-launch-modal').modal('hide');
+          component.set('taleToCopy', null);
+        },
+        
+        submitCopyAndLaunch(taleToCopy) {
+          console.log("Submitted.");
+          
+          const self = this;
+          self.set('copyingTale', true);
+          const originalTale = self.get('taleToCopy');
+          if (originalTale) {
+              
+              let handleLaunchError = (tale, err) => {
+                // deal with the failure here
+                //tale.set('launchStatus', 'error');
+                //tale.set('launchError', err.message || err);
+                
+                console.error('Failed to launch Tale', err);
+              };
+              
+            self.get('apiCall').copyTale(originalTale).then(taleCopy => {
+              let eTaleCopy = EmberObject.create(taleCopy);
+              self.apiCall.startTale(eTaleCopy).then((instance) => {
+                console.log(`Transitioning to /run/${eTaleCopy._id}`);
+                self.router.transitionTo('run.view', eTaleCopy._id);
+                self.apiCall.waitForInstance(instance).then((instance) => {
+                    console.log('Tale is now started:', eTaleCopy);
+                  }).catch((err) => handleLaunchError(eTaleCopy, err));
+              }).catch((err) => handleLaunchError(eTaleCopy, err));
+            });
+          }
+        },
+                
+                
+                
+                // Dead code: 
+                
+                
+                
+                
+                /*
+              self.set('copyingTale', false);
+              self.actions.closeCopyOnLaunchModal.call(self);
+              
+              // Convert JSON response to an EmberObject
+              let eTaleCopy = EmberObject.create(taleCopy);
+              
+              // Push to models in view
+              // TODO: Detect filtered view?
+              const tales = self.get('modelsInView');
+              if (tales) {
+                  tales.pushObject(eTaleCopy);
+                  self.set('modelsInView', A(tales));
+              }
+              
+              // Reset state manually when re-launching
+              eTaleCopy.set('launchError', null);
+              eTaleCopy.set('launchStatus', 'starting');
+              eTaleCopy.set('launchResetRequest', null);
+          
+                
+              
+              // Launch the newly-copied tale
+              return self.apiCall.startTale(eTaleCopy).then((instance) => {
+                eTaleCopy.set('instance', instance);
+                self.apiCall.waitForInstance(instance).then((instance) => {
+                    eTaleCopy.set('instance', instance);
+                    self.get('taleLaunched')();
+                    eTaleCopy.set('launchError', null);
+                    eTaleCopy.set('launchStatus', 'started');
+                    console.log('Tale is now started:', eTaleCopy);
+                    resetStatusAfterMs(eTaleCopy, 10000);
+                  }).catch((err) => handleLaunchError(eTaleCopy, err));
+              }).catch((err) => handleLaunchError(eTaleCopy, err));
+            });
+          } else {
+            console.log('No tale to copy... something went wrong!');
+          }*/
+    }
+});

--- a/app/components/ui/copy-on-launch-modal/template.hbs
+++ b/app/components/ui/copy-on-launch-modal/template.hbs
@@ -1,0 +1,23 @@
+
+<div id="copy-on-launch-modal" class="ui small modal">
+  <i class="close icon"></i>
+  <div class="header">
+    <i class="fas fa-exclamation-triangle icon"></i>
+    Insufficient Access
+  </div>
+  <div class="content">
+    <p>You do not have sufficient access to run this Tale, but you can create your own copy!</p>
+    <p></p>
+    <p>Create a copy of this Tale and run the copy now?</p>
+  </div>
+  <div class="actions">
+    <div class="ui black deny button" {{action 'closeCopyOnLaunchModal'}}>
+      <i class="remove icon"></i>
+      Cancel
+    </div>
+    <div class="ui positive right labeled icon button" {{action 'submitCopyAndLaunch' taleToCopy}}>
+      Copy and Run
+      <i class="checkmark icon"></i>
+    </div>
+  </div>
+</div>

--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -276,88 +276,17 @@ export default Component.extend({
       this.sendAction("onAddNew");
     },
     
-    closeCopyOnLaunchModal() {
-      const component = this;
-      $('#copy-on-launch-modal').modal('hide');
-      component.set('taleToCopy', null);
-    },
-    
     openCopyOnLaunchModal(taleToCopy) {
       const component = this;
       $('#copy-on-launch-modal').modal('show');
       component.set('taleToCopy', taleToCopy);
     },
-    
-    submitCopyAndLaunch(taleToCopy) {
-      const self = this;
-      self.set('copyingTale', true);
-      const originalTale = self.get('taleToCopy');
-      if (originalTale) {
-        self.get('apiCall').copyTale(originalTale).then(taleCopy => {
-          self.set('copyingTale', false);
-          self.actions.closeCopyOnLaunchModal.call(self);
-          
-          // Convert JSON response to an EmberObject
-          let eTaleCopy = EmberObject.create(taleCopy);
-          
-          // Push to models in view
-          // TODO: Detect filtered view?
-          const tales = self.get('modelsInView');
-          tales.pushObject(eTaleCopy);
-          self.set('modelsInView', A(tales));
-          
-          // Reset state manually when re-launching
-          eTaleCopy.set('launchError', null);
-          eTaleCopy.set('launchStatus', 'starting');
-          eTaleCopy.set('launchResetRequest', null);
-      
-            
-          // TODO: Abstract this to reusable helper?
-          let resetStatusAfterMs = (tale, delay) => {
-            let resetRequest = later(() => {
-              if (!self.isDestroyed) {
-                console.log('Resetting tale status:', tale);
-                tale.set('launchError', null);
-                tale.set('launchStatus', null);
-                tale.set('launchResetRequest', null);
-              }
-            }, delay);
-            tale.set('launchResetRequest', resetRequest);
-          };
-        
-          // TODO: Abstract this to reusable helper?
-          let handleLaunchError = (tale, err) => {
-            // deal with the failure here
-            tale.set('launchStatus', 'error');
-            tale.set('launchError', err.message || err);
-            
-            resetStatusAfterMs(tale, 10000);
-            console.error('Failed to launch Tale', err);
-          };
-          
-          // Launch the newly-copied tale
-          return this.apiCall.startTale(eTaleCopy).then((instance) => {
-            eTaleCopy.set('instance', instance);
-            this.apiCall.waitForInstance(instance).then((instance) => {
-                eTaleCopy.set('instance', instance);
-                self.get('taleLaunched')();
-                eTaleCopy.set('launchError', null);
-                eTaleCopy.set('launchStatus', 'started');
-                console.log('Tale is now started:', eTaleCopy);
-                resetStatusAfterMs(eTaleCopy, 10000);
-              }).catch((err) => handleLaunchError(eTaleCopy, err));
-          }).catch((err) => handleLaunchError(eTaleCopy, err));
-        });
-      } else {
-        console.log('No tale to copy... something went wrong!');
-      }
-    },
 
     startTale(tale) {
-      const self = this;
+      const component = this;
       if (tale._accessLevel < 1) {
         // Prompt for confirmation before copying and launching
-        self.actions.openCopyOnLaunchModal.call(self, tale);
+        component.actions.openCopyOnLaunchModal.call(self, tale);
         return;
       }
 
@@ -375,7 +304,7 @@ export default Component.extend({
       // TODO: Abstract this to reusable helper?
       let resetStatusAfterMs = (tale, delay) => {
         let resetRequest = later(() => {
-          if (!self.isDestroyed) {
+          if (!component.isDestroyed) {
             console.log('Resetting tale status:', tale);
             tale.set('launchError', null);
             tale.set('launchStatus', null);
@@ -389,7 +318,7 @@ export default Component.extend({
         let startLooping = function(func){
           return later(function(){
             currentLoop = startLooping(func);
-            component.get('store').findRecord('instance', instance.get('_id'), { reload:true })
+            component.get('store').findRecord('instance', tale.instance.get('_id'), { reload:true })
               .then(model => {
                 if(model.get('status') === 1) {
                   component.get('taleLaunched')();

--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -286,7 +286,7 @@ export default Component.extend({
       const component = this;
       if (tale._accessLevel < 1) {
         // Prompt for confirmation before copying and launching
-        component.actions.openCopyOnLaunchModal.call(self, tale);
+        component.actions.openCopyOnLaunchModal.call(component, tale);
         return;
       }
 

--- a/app/components/ui/tale-browser/template.hbs
+++ b/app/components/ui/tale-browser/template.hbs
@@ -128,11 +128,10 @@
     <div class="ui grid">
         <div class="twelve wide column" id="tale-filters">
             <div id="tale-filter-items" class="ui compact menu">
-                <a class="item clickable tale-filter-item {{if (eq currentTab 'all') 'active'}}" {{action 'selectFilter' 'all'}}>
+                <a class="item clickable tale-filter-item {{if (eq filter 'All') 'active'}}" {{action 'selectFilter' 'All'}}>
                     All Tales
                 </a>
-                {{!-- To enable tab:  {{action 'selectFilter' 'mine'}} --}}
-                <a class="item not clickable tale-filter-item {{if (eq currentTab 'mine') 'active'}}">
+                <a class="item clickable tale-filter-item {{if (eq filter 'Mine') 'active'}}" {{action 'selectFilter' 'Mine'}}>
                     My Tales
                 </a>
             </div>
@@ -424,25 +423,4 @@
     </div>
 </div>
 
-<div id="copy-on-launch-modal" class="ui small modal">
-  <i class="close icon"></i>
-  <div class="header">
-    <i class="fas fa-exclamation-triangle icon"></i>
-    Insufficient Access
-  </div>
-  <div class="content">
-    <p>You do not have sufficient access to run this Tale, but you can create your own copy!</p>
-    <p></p>
-    <p>Create a copy of this Tale and run the copy now?</p>
-  </div>
-  <div class="actions">
-    <div class="ui black deny button" {{action 'closeCopyOnLaunchModal'}}>
-      <i class="remove icon"></i>
-      Cancel
-    </div>
-    <div class="ui positive right labeled icon button" {{action 'submitCopyAndLaunch' taleToCopy}}>
-      Copy and Run
-      <i class="checkmark icon"></i>
-    </div>
-  </div>
-</div>
+{{ui/copy-on-launch-modal taleToCopy=taleToCopy modelsInView=modelsInView}}


### PR DESCRIPTION
### Problem
After merging Copy on Launch + the various refactoring branches, the Run view still allows users to start a Tale to which they do not have access.

Fixes #513

### Approach
Refactor the `copy-on-launch-modal` into its own reusable component and add it to the Run view. 

Other minor changes:
* Fixes #512: added a label to the Run view to indicate that the currently running Tale is a `COPY`

### How to Test
Prerequisite: At least one Tale that you do not own, shut down all instances with `./destroy_instances.py`

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Browse view
4. Choose a tale that you do not own and hit the "Run" button
    * You should be prompted with the Copy on Launch modal
5. Click "Copy and Run" to confirm
    * The modal should close
    * You should be brought directly to the Run > Interact view for the newly copied Tale
    * You should see a label at the top-left indicating that this Tale is indeed a `COPY`
    * The Tale should already be starting (you should see notifications / status message on screen)
6. Choose a tale that you do not own and hit the "View" button
    * You should be taken to the "Run" view for this Tale
7. Click the "Run" button at the top-right
    * You should be prompted with the same Copy on Launch modal as before
8. Click "Copy and Run" to confirm
    * The modal should close
    * You should be brought directly to the Run > Interact view for the newly copied Tale
    * You should see a label at the top-left indicating that this Tale is indeed a `COPY`
    * The Tale should already be starting (you should see notifications / status message on screen)