### PR TITLE
Add a margin to the tale browser top

### DIFF
--- a/app/components/ui/tale-browser/template.hbs
+++ b/app/components/ui/tale-browser/template.hbs
@@ -267,7 +267,7 @@
                 </table>
             </div>
         {{else}}
-            <div id="tales-table" class="ui {{cardsPerRow}} doubling selectable cards {{guid}} tales-table-short-intro" style="padding: 5px 20px 5px 20px; margin-bottom: 1em;">
+            <div id="tales-table" class="ui {{cardsPerRow}} doubling selectable cards {{guid}} tales-table-short-intro" style="padding: 5px 20px 5px 20px; margin-bottom: 1em; margin-top: 1em;">
                 {{#each modelsInView as |model|}}
                     <div class="tale card">
                         <div class="extra content">


### PR DESCRIPTION
It looks like font awesome was assigning a negative border value at runtime. This overrides it with a margin of 1em. Fixes #518 

To Test:
1. Check this branch out
2. Deploy
3. Make sure you have enough Tales to scroll on the browse page
4. Scroll
5. Note that the header is not run over

See it in action here
https://recordit.co/d8gbwAL4Dv