### PR TITLE
Hide the ADC from the publishing menu

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -316,12 +316,15 @@ export default Component.extend(FullScreenMixin, {
           coordinatingNode: 'https://cn.dataone.org/cn/v2',
           isProduction: true
         },
+        /*
+        DEVNOTE: The ADC is currently disabled until a curation workflow is implemented
         {
           name: 'DataONE-Arctic Data Center',
           memberNode: 'https://arcticdata.io/metacat/d1/mn',
           coordinatingNode: 'https://cn.dataone.org/cn/v2',
           isProduction: true
         }
+        */
       ];
 
       // An array of the repositories that we show


### PR DESCRIPTION
This PR hides the dropdown item for the ADC repository. There's going to be be discussion next week (Sept. 2-6) about workflows; this feature will be revised after.

To Test: 
1. Check this PR out
2. Change `if(config.dev) {` on line 334 to `if(!config.dev) {` (So that production repos show up)
3. Open the publish modal
4. Note that the ADC is missing