### PR TITLE
Fix instance popout link on Run > Interact

### DIFF
--- a/app/components/ui/tale-tabs-selector/template.hbs
+++ b/app/components/ui/tale-tabs-selector/template.hbs
@@ -8,7 +8,7 @@
         <a class="item {{if activeTabFiles "active"}} auto-width" data-tab="tab-files" {{action "activateFiles"}}>Files</a>
         <a class="item {{if activeTabMetadata "active"}} auto-width" data-tab="tab-metadata" {{action "activateMetadata"}}>Metadata</a>
         {{#if (and activeTabInteract (and model.instance (and (not-eq model.instance.status 0) (and model.instance.iframe (eq internalState.currentInstanceId model.id)))))}}
-            <a href="{{model.url}}" target="_blank" class="external-icon-container">
+            <a href="{{model.instance.url}}" target="_blank" class="external-icon-container">
                 <i class="external alternate right icon floated"></i>
             </a>
         {{/if}}


### PR DESCRIPTION
## Problem
Popout (aka "open in new tab") link is broken on Run > Interact. It appears to be looking at the wrong value to get the `instance.url`.

Fixes #533 

## Approach
Use `model.instance.url` instead of `model.url`. Whoops.

## How to Test
Prerequisites: `LIGO Tutorial` Tale registered

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Run the `LIGO Tutorial` Tale - you will need to "Copy and Launch" to start this
    * You should be brought to the Run > Interact view while your Tale is starting
4. Wait for the Tale to start
5. At the top-right, click the popout button (external link icon)
    * You should see your Tale open in a new tab (instead of an iframe)