### PR TITLE
Fix the Generate Illustration button on Run > Metadata. Fixes #538

### DIFF
--- a/app/components/ui/tale-tab-metadata/component.js
+++ b/app/components/ui/tale-tab-metadata/component.js
@@ -216,7 +216,7 @@ export default Component.extend({
       })
         .then(sils => {
           sils.forEach(result => {
-            let tale = this.get('model').get('tale');
+            let tale = this.get('model');
             tale.set('illustration', result.get('icon'));
           })
         });


### PR DESCRIPTION
## Problem
"Generate Illustration" no longer works, and only generates a stack trace.

Fixes #538 

## Approach
Fix the button.

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the "Run > Metadata" view of a Tale to which you have write access
4. Scroll down and click the Generate Illustration button
    * You should see a new URL appear in the icon input
    * Your icon on the `wt-paddleboard` along the top of the view should update to display a new icon