### PR TITLE
Fixed readonly inputs on Run > Metadata. Fixes #537

### DIFF
--- a/app/components/ui/markdown-editor/component.js
+++ b/app/components/ui/markdown-editor/component.js
@@ -1,10 +1,12 @@
 // app/pods/components/markdown-component/component.js
-import Ember from 'ember';
+import Component from '@ember/component';
+import { later } from '@ember/runloop';
 import layout from './template';
 
-export default Ember.Component.extend({
+export default Component.extend({
     layout,
 
+    readonly: false,
     markdownValue: "",
 
     didInsertElement() {
@@ -12,9 +14,15 @@ export default Ember.Component.extend({
           .tab()
         ;
 
+        if (this.get('readonly')) {
+            later(function() {
+                $('.ui.menu').find('.item').tab('change tab', 'preview');
+            },500);
+        }
+
         if(!this.markdownValue) {
             let component = this;
-            Ember.run.later(function() {
+            later(function() {
                 component.set('markdownValue', "#### Markdown Editor");
             },1);
         }

--- a/app/components/ui/markdown-editor/template.hbs
+++ b/app/components/ui/markdown-editor/template.hbs
@@ -9,7 +9,7 @@
     </a>
 </div>
 <div class="ui bottom attached tab segment active" data-tab="edit">
-    {{textarea value=markdownValue}}
+    {{textarea value=markdownValue readonly=readonly}}
 </div>
 <div class="ui bottom attached tab segment" data-tab="preview">
     {{convert-markdown markdownValue}}

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -58,7 +58,7 @@
     <div class="inline fields ui grid">
         <label class="two wide column right aligned">Environment</label>
         <div class="field thirteen wide column">
-            <div id="environmentDropdown" class="ui icon selection dropdown image {{if (eq environments.length 0) "loading"}}">
+            <div id="environmentDropdown" class="ui icon selection dropdown image {{if (eq environments.length 0) "loading"}} {{if cannotEditTale "disabled"}}"  disabled={{cannotEditTale}}>
                 <input name="TaleImageId" type="hidden" onchange={{action "setTaleEnvironment" value="target.value"}}>
                 <i class="dropdown icon"></i>
                 <div class="default text"> Choose an environment...</div>
@@ -92,7 +92,7 @@
     <div class="inline fields ui grid">
         <label class="two wide column right aligned">License</label>
         <div class="field thirteen wide column">
-            <div id="licenseDropdown" class="ui icon selection dropdown license {{if (eq licenses.length 0) "loading"}}">
+            <div id="licenseDropdown" class="ui icon selection dropdown license {{if (eq licenses.length 0) "loading"}} {{if cannotEditTale "disabled"}}"  disabled={{cannotEditTale}}>
                 <input name="TaleLicenseSPDX" type="hidden" onchange={{action "setTaleLicense" value="target.value"}}>
                 <i class="dropdown icon"></i>
                 <div class="default text"> Choose a license...</div>
@@ -124,7 +124,7 @@
     <div class="inline fields ui grid">
         <label class="two wide column right aligned">Description</label>
         <div class="thirteen wide column">
-            {{ui/markdown-editor markdownValue=model.description}}
+            {{ui/markdown-editor markdownValue=model.description readonly=cannotEditTale}}
         </div>
     </div>
 
@@ -134,7 +134,7 @@
             {{input id=tale-icon value=model.illustration placeholder="http://" readonly=cannotEditTale}}
             <div class="ui buttons">
                 <div class="or"></div>
-                <button class="ui positive blue button" {{action "generateIcon"}}>Generate Illustration</button>
+                <button class="ui positive blue button {{if cannotEditTale "disabled"}}"  disabled={{cannotEditTale}} {{action "generateIcon"}}>Generate Illustration</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Problem
When viewing a read-only Tale, some inputs on the Run > Metadata view are still editable. This could cause confusion.

Fixes #537 

## Approach
* Updated the License/Environment dropdowns to be read-only when the user cannot edit the Tale
* Disable the Generate Illustration button when the user cannot edit the Tale
* Updated the Description input's Markdown Editor to show the Preview tab by default, and to prevent editing in the Edit tab

## How to Test
Prerequisites: Register the LIGO Tale (or another read-only public Tale)

1. Checkout and run ths branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Run > Metadata view for the LIGO Tale
4. Attempt to edit the License or Environment
    * These dropdowns should be disabled
5. Attempt to edit the Description
    * The Markdown Editor should be defaulted to the Preview tab
    * The `textarea` in the edit tab should be readonly
    * You should be able to copy this text to your clipboard, if desired
6. Attempt to Generate a new Illustration
    * This button should be disabled