### PR TITLE
Reset Select Data modal when clicking Cancel

### DIFF
--- a/app/components/ui/tale-tab-files/component.js
+++ b/app/components/ui/tale-tab-files/component.js
@@ -499,8 +499,11 @@ export default Component.extend({
                     context.actions.closeSelectDataModal();
                 });
         },
-
         openSelectDataModal() {
+            this.set('allSelectedItems', A(this.get('model').get('dataSet').map(item => {
+                let {itemId, mountPath, _modelType} = item;
+                return O({id: itemId, name: mountPath.replace(/\//g, ''), _modelType});
+            })));
             $('.ui.modal.selectdata').modal('show');
         },
         closeSelectDataModal() {


### PR DESCRIPTION
## Problem
When clicking Cancel on the Select Data modal, the user's selection is not cleared. The next time the user opens the modal, their previously-added data is still present. This could cause confusion.

Fixes #539 

## Approach
When opening the modal, parse the Tale's `dataSet` list and explicitly set that as the content of the modal.

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the "Run > Files" view for a Tale
4. On the left side, click the External Data nav
5. At the top-right, click the (+) button
    * The Select Data modal should open
6. Add some new datasets, then click "Cancel"
    * The modal should dismiss
    * The datasets listed in the `directory-browser` on the Run > Files view should not have changed
7. At the top-right, click the (+) button
    * The Select Data modal should open again
    * You should no longer see the datasets that were added then cancelled
    * The modal should only show datasets that are already added to the Tale