### PR TITLE
Disable (+) button on Run > Files when Tale is readonly

### DIFF
--- a/app/components/ui/files/bread-crumbs/component.js
+++ b/app/components/ui/files/bread-crumbs/component.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import layout from './template';
 
-const taleStatus = Object.create({
+const TaleAccessLevel = Object.create({
   NONE: -1,
   READ: 0,
   WRITE: 1,
@@ -19,7 +19,7 @@ export default Component.extend({
   
   // Flag that can be used to tell if the current user has permission to edit the Tale
   canEditTale: computed('model._accessLevel', function () {
-        return this.get('model') && this.get('model') && this.get('model').get('_accessLevel') >= taleStatus.WRITE;
+        return this.get('model') && this.get('model') && this.get('model').get('_accessLevel') >= TaleAccessLevel.WRITE;
   }).readOnly(),
   cannotEditTale: computed.not('canEditTale').readOnly(),
 

--- a/app/components/ui/files/bread-crumbs/component.js
+++ b/app/components/ui/files/bread-crumbs/component.js
@@ -1,12 +1,27 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import layout from './template';
+
+const taleStatus = Object.create({
+  NONE: -1,
+  READ: 0,
+  WRITE: 1,
+  ADMIN: 2,
+  SITE_ADMIN: 100
+});
 
 export default Component.extend({
   layout,
   classNames: ['breadcrumbs-container'],
   internalState: service(),
   displayFoldersMenu: false,
+  
+  // Flag that can be used to tell if the current user has permission to edit the Tale
+  canEditTale: computed('model._accessLevel', function () {
+        return this.get('model') && this.get('model') && this.get('model').get('_accessLevel') >= taleStatus.WRITE;
+  }).readOnly(),
+  cannotEditTale: computed.not('canEditTale').readOnly(),
 
   actions: {
     breadcrumbClicked(item) {
@@ -33,6 +48,7 @@ export default Component.extend({
     },
 
     triggerBreadcrumbAction(currentNavName) {
+        if(this.get('cannotEditTale')) { return; }
         if(currentNavName === 'Data') {
             this.get('openSelectDataModal')();
         } else {

--- a/app/components/ui/files/bread-crumbs/component.js
+++ b/app/components/ui/files/bread-crumbs/component.js
@@ -48,7 +48,7 @@ export default Component.extend({
     },
 
     triggerBreadcrumbAction(currentNavName) {
-        if(this.get('cannotEditTale')) { return; }
+        if(this.get('cannotEditTale') && this.get('currentNav').command !== 'home') { return; }
         if(currentNavName === 'Data') {
             this.get('openSelectDataModal')();
         } else {

--- a/app/components/ui/files/bread-crumbs/template.hbs
+++ b/app/components/ui/files/bread-crumbs/template.hbs
@@ -19,7 +19,7 @@
                 {{#if (and (lt model.tale._accessLevel 1) (or (eq currentNav.command 'workspace') (eq currentNav.command 'user_data')))}}
                     <i id="add-item-button" class="fas fa-plus-circle icon blue large disabled" disabled style="cursor:not-allowed !important;"></i>
                 {{else}}
-                    <i id="add-item-button" class="fas fa-plus-circle icon blue large {{if cannotEditTale "disabled"}}" disabled={{cannotEditTale}} {{action 'triggerBreadcrumbAction' currentNav.name}}></i>
+                    <i id="add-item-button" class="fas fa-plus-circle icon blue large {{if (and cannotEditTale (not (eq currentNav.command 'home'))) "disabled"}}" disabled={{if (and cannotEditTale (not (eq currentNav.command 'home'))) "true" "false"}} {{action 'triggerBreadcrumbAction' currentNav.name}}></i>
                 {{/if}}
                 {{#if displayFoldersMenu}}
                     {{#click-outside action=(action (mut displayFoldersMenu) false)}}

--- a/app/components/ui/files/bread-crumbs/template.hbs
+++ b/app/components/ui/files/bread-crumbs/template.hbs
@@ -19,7 +19,7 @@
                 {{#if (and (lt model.tale._accessLevel 1) (or (eq currentNav.command 'workspace') (eq currentNav.command 'user_data')))}}
                     <i id="add-item-button" class="fas fa-plus-circle icon blue large disabled" disabled style="cursor:not-allowed !important;"></i>
                 {{else}}
-                    <i id="add-item-button" class="fas fa-plus-circle icon blue large" {{action 'triggerBreadcrumbAction' currentNav.name}}></i>
+                    <i id="add-item-button" class="fas fa-plus-circle icon blue large {{if cannotEditTale "disabled"}}" disabled={{cannotEditTale}} {{action 'triggerBreadcrumbAction' currentNav.name}}></i>
                 {{/if}}
                 {{#if displayFoldersMenu}}
                     {{#click-outside action=(action (mut displayFoldersMenu) false)}}


### PR DESCRIPTION
## Problem
In the Run > Files view for read-only Tales, the (+) button is still enabled. This could lead the user to believe that they can freely add files, although the API operations themselves will fail due to permissions errors.

Fixes #541 

## Approach
Disable the (+) button when the Tale is not writable. There is logic already there for this, but it was unclear why it no longer functions.

## How to Test
Prerequisites: Register the LIGO Tale (or another read-only public Tale)

1. Checkout and run ths branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Run > Files view for the LIGO Tale
4. On the left side, click the Home nav
    * You should see the (+) button at the top-right is **enabled**
4. On the left side, click the External Data nav
    * You should see the (+) button at the top-right is **disabled**
4. On the left side, click the Tale Workspace nav
    * You should see the (+) button at the top-right is **disabled**