### PR TITLE
Restore per-item dropdown options to Run > Files > Tale Workspace

### DIFF
--- a/app/components/ui/files/directory-browser/template.hbs
+++ b/app/components/ui/files/directory-browser/template.hbs
@@ -40,7 +40,7 @@
                                 <a class="item" href="{{apiUrl}}/{{item._modelType}}/{{item.id}}/download?contentDisposition=attachment">
                                     <i class="download icon"></i> Download
                                 </a>
-                                {{#unless (or notInManagePage (lt model.tale._accessLevel 1))}}
+                                {{#unless (or notInManagePage (lt model._accessLevel 1))}}
                                 <a class="item" href="#" {{action "removeDataset" item.id}}>
                                     <i class="trash icon"></i> Remove
                                 </a>
@@ -60,11 +60,20 @@
             {{#each sessionList as |item|}}
                 <tr class="left aligned contextmenu" id="{{item.id}}">
                     <td colspan="3">
-                        {{#if (eq item._modelType "folder")}}
-                            <i class="large folder icon"></i> {{item.name}}
-                        {{else}}
-                            {{{file-icon-for item.name}}} {{item.name}}
-                        {{/if}}
+                        {{#ui-dropdown}}
+                            {{!-- When clicking an item, show the dropdown --}}
+                            {{#if (eq item._modelType "folder")}}
+                                <i class="large folder icon"></i> {{item.name}}
+                            {{else}}
+                                {{{file-icon-for item.name}}} {{item.name}}
+                            {{/if}}
+                            <i class="dropdown icon"></i>
+                            <div class="menu">
+                                <a class="item" href="{{apiUrl}}/{{item._modelType}}/{{item.id}}/download?contentDisposition=attachment">
+                                    <i class="download icon"></i> Download
+                                </a>
+                            </div>
+                        {{/ui-dropdown}}
                     </td>
                 </tr>
             {{/each}}
@@ -93,12 +102,12 @@
                                     {{/if}}
                                     
                                     {{!-- Only show if Home folder, or if Workspace with write access --}}
-                                    {{#if (or (and (eq currentNav.command 'workspace') (gt model.tale._accessLevel 0)) (eq currentNav.command 'home'))}}
+                                    {{#if (or (and (eq currentNav.command 'workspace') (gt model._accessLevel 0)) (eq currentNav.command 'home'))}}
                                         <a class="item" {{action "rename" item}}><i class="write square icon"></i>
                                             Rename...</a>
                                         {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a>--}}
                                         {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
-                                            {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
+                                            <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
                                         {{else}}
                                             <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
                                         {{/if}}
@@ -143,12 +152,12 @@
                                     {{#if (eq currentNav.command 'home')}}
                                         <a class="item" {{action "move" item}}><i class="folder icon"></i> Move To...</a>
                                     {{/if}}
-                                    {{#if (or (and (eq currentNav.command 'workspace') (gt model.tale._accessLevel 0)) (eq currentNav.command 'home'))}}
+                                    {{#if (or (and (eq currentNav.command 'workspace') (gt model._accessLevel 0)) (eq currentNav.command 'home'))}}
                                         <a class="item" {{action "rename" item}}><i class="write square icon"></i>
                                             Rename...</a>
                                         {{!-- <a class="item" {{action "share" item}}><i class="share icon"></i> Share</a> --}}
                                         {{#if (and notInManagePage (eq currentNav.command 'workspace'))}}
-                                            {{!-- <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a> --}}
+                                            <a class="item" {{action "copyToHome" item}}><i class="clone icon"></i> Copy to Home</a>
                                         {{else}}
                                             <a class="item" {{action "copy" item}}><i class="clone icon"></i> Copy</a>
                                         {{/if}}


### PR DESCRIPTION
## Problem
Run > Files > Tale Workspace is missing some per-item dropdown options. Currently, we only show "Download", but would also like to show the other usual file operations as well.

Fixes #540 

## Approach
* Show Rename/Remove/Copy/Download for Tale Workspace
* Show only 'Download' for ExtData

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Run > Files view for a tale
4. On the left side, click the Tale Workspace nav
    * You should see the content of the Tale Workspace populate the right panel
5. Expand the dropdown menu beside a folder (create one if you haven't already)
    * You should see options for "Rename", "Remove", "Download", and "Copy to Home"
6. Expand the dropdown menu beside a file (upload one if you haven't already)
    * You should see options for "Rename", "Remove", "Download", and "Copy to Home"
7. On the left side, click the External Data nav
    * You should see the Tale's external datasets populate the right panel
8. Expand the dropdown menu beside a dataset (add one if you haven't already)
    * You should only see options for "Download" listed here