### PR TITLE
Added asTale support to create-tale-modal

### DIFF
--- a/app/components/dashboard/browse/left-panel/component.js
+++ b/app/components/dashboard/browse/left-panel/component.js
@@ -24,7 +24,7 @@ export default Component.extend(FullScreenMixin, {
       action: 'select',
       showOnFocus:false
     });
-    this.router.transitionTo({ queryParams: { environment: null, name: null, uri: null }});
+    this.router.transitionTo({ queryParams: { environment: null, name: null, uri: null, api: null, asTale: null }});
   },
   
   actions: {

--- a/app/routes/browse.js
+++ b/app/routes/browse.js
@@ -17,7 +17,9 @@ export default AuthenticateRoute.extend({
     // An optional API URL that can be used to access information about the dataset
     api: {refreshModel:true},
     // An optional environment name
-    environment: {refreshModel:true}
+    environment: {refreshModel:true},
+    // Whether to import data as Dataset or as a Workspace
+    asTale: {refreshModel:true}
   },
 
   async model(queryParams) {


### PR DESCRIPTION
## Problem
The new `create-tale-modal` does not handle importing with the `asTAle` option enabled. This flag tells the Girder worker to import data directly into the newly-created Tale's Workspace, instead of registering it as External Data.

Fixed #547 

## Approach
Added support for the `asTale` query string parameter. Pass this parameter through to the API call for `POST /tale/import`, and make sure we clear it from the address bar when we clear the others.

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate directly to https://dashboard.local.wholetale.org/browse?uri=https%3A%2F%2Fdataverse.harvard.edu%2Fdataset.xhtml%3FpersistentId%3Ddoi%3A10.7910%2FDVN%2F3MJ7IR&name=Replication+Data+for%3A+"Agricultural+Fires+and+Health+at+Birth&asTale=True
    * Note the `asTale=True` query string parameter
4. Open your Developer Console to the Networks tab
5. Choose an environment and submit the form
6. Check the Networks tab and search for the `import` API call
    * You should see that the `asTale=true` parameter was passed through to the API call
7. Wait a couple of minutes for the Tale import to complete
8. Navigate to Run > Files for the newly-imported Tale
    * You should see that Run > Files > Tale Workspace is **populated with data**
    * You should see that Run > Files > External Data is **empty**