### PR TITLE
Fixed incorrect button state in Browse view

### DIFF
--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -313,7 +313,10 @@ export default Component.extend({
           eTaleCopy.set('launchStatus', 'starting');
           return self.get('apiCall').startTale(eTaleCopy).then((instance) => {
             eTaleCopy.set('instance', instance);
-            self.get('apiCall').waitForInstance(instance);
+            self.get('apiCall').waitForInstance(instance).then(() => {
+              eTaleCopy.set('launchError', null);
+              eTaleCopy.set('launchStatus', 'started');
+            });
             later(() => self.router.transitionTo('run.view', eTaleCopy._id), 500);
           }).catch(err => {
             console.error('Failed to launch Tale', err);
@@ -337,7 +340,10 @@ export default Component.extend({
       tale.set('launchStatus', 'starting');
       return self.apiCall.startTale(tale).then((instance) => {
         tale.set('instance', instance);
-        self.get('apiCall').waitForInstance(instance);
+        self.get('apiCall').waitForInstance(instance).then(() => {
+          tale.set('launchError', null);
+          tale.set('launchStatus', 'started');
+        });
         self.router.transitionTo('run.view', tale._id);
       }).catch(err => {
         console.error('Failed to launch Tale', err);


### PR DESCRIPTION
## Problem
When launching a Tale from the Browse view, we need to keep track of which Tales are launching/launched/stopped/stopping/etc, or which ones have encountered an error and what the error said. Because this is not tracked in the API, we've needed to invent some state in the `tale-browser` code that keeps track of this.

We've neglected to reset this status upon a new instance finishing being launched, since I assumed that navigating would cause the page to repopulate - this is apparently not the case.

Fixes #549 

## Approach
Added a callback handler to reset the button state once the instance is up for both of "Launch Tale" use cases in the Browse view: `startTale` and `submitCopyAndLaunch`

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Browse view
4. Launch a Tale
    * You should be automatically navigated to the Run > Interact view
5. Click your browser's back button or the "Return to Dashboard" link at the top-left
    * You should be brought back to the Browse view
    * You should see a spinner on the Tale's button
6. While the Tale is still launching, right-click the tab in your browser and choose `Duplicate Tab`
    * A new tab should open to the Browse view - call this Tab 2, where your original one is Tab 1
    * Note that the spinner is also present in Tab 2
7. Wait for the Tale to finish launching, then "Duplicate Tab" again
    * Another new tab should open to the Browse view - call this Tab 3
    * Note that the spinner is **not** present in Tab 3
    * The Tale's button should be enabled
    * The button should read `Stop`
8. Check Tabs 1 & 2 again to verify button state matches that of Tab 3
    * The spinner should no longer be present
    * The Tale's button should be enabled
    * The button should read `Stop`