### PR TITLE
Do not show add/remove author on readonly tale. Fixes #554

### DIFF
--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -28,7 +28,9 @@
               <div class="field">
                 {{input type="url" name='orcid-id' placeholder="https://orcid.org/0000-0002-1825-0097"  value=author.orcid readonly=cannotEditTale }}
               </div>
-              <i class="fa fa-window-close" aria-hidden="true" {{action 'removeAuthor' index}}></i>
+              {{#if (not cannotEditTale)}}
+                <i class="fa fa-window-close" aria-hidden="true" {{action 'removeAuthor' index}}></i>
+              {{/if}}
             </div>
           </div>
         </div>
@@ -40,6 +42,7 @@
       </div>
     {{/if}}
       
+    {{#if (not cannotEditTale)}}
     <div class="inline fields ui grid">
         <label class="two wide column right aligned"></label>
         <div class="field thirteen wide column add-author">
@@ -47,6 +50,7 @@
             <span {{action 'addNewAuthor'}}>&nbsp;Add an{{if taleAuthors 'other'}} author</span>
         </div>
     </div>
+    {{/if}}
 
     <div class="inline fields ui grid">
         <label class="two wide column right aligned">Category</label>


### PR DESCRIPTION
1. Register Ligo
2. Navigate to Run > Metadata of Ligo Tale
3. "+ Add an author" shouldn't be there
4. "x" next to current author should be gone.