### PR TITLE
Adjust z-index on error message. Fixes #555

### DIFF
--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -61,13 +61,10 @@
                         <div class="tale-instance-menu">
                             <div class="ui vertical left menu transition">
                                 <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/run.html" target="_blank">
-                                    Read the docs <div class="ui label transparent"><i class="fas fa-book"></i></div>
+                                    Learn more <div class="ui label transparent"><i class="fas fa-book"></i></div>
                                 </a>
                                 <a class="item"  {{action "exportTale" model.id 'bagit'}}>
                                   Export as BagIt <div class="ui label transparent"><i class="fas fa-archive"></i></div>
-                                </a>
-                                <a class="item" {{action "exportTale" model.id 'native'}}>
-                                  Export as Zip <div class="ui label transparent" ><i class="far fa-file-archive"></i></div>
                                 </a>
                                 {{!-- Only allow Tale Admins to access publish function --}}
                                 {{#if (gt model._accessLevel 1)}}

--- a/app/components/ui/tale-browser/template.hbs
+++ b/app/components/ui/tale-browser/template.hbs
@@ -348,7 +348,7 @@
                                 {{!-- Display launch error, if necessary --}}
                                 {{#if model.launchError}}
                                 <div class="extra content" style="height:0;margin:0;padding:0;">
-                                    <div class="ui tiny red message" style="max-height:200px;margin-top:5px;margin-bottom:20px;">
+                                    <div class="ui tiny red message" style="max-height:200px;margin-top:5px;margin-bottom:20px;z-index:999;">
                                         <i class="close icon" {{action 'dismissLaunchError' model}}></i>
                                         <p>{{model.launchError}}</p>
                                     </div>


### PR DESCRIPTION
Additionally this removes obsolete "Export as Zip" and changes wording from "Read the Docs" to "Learn More".