### PR TITLE
Replace logout/gravatar nav items with a more scalable dropdown menu

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -4,6 +4,7 @@ import EventStream from 'npm:sse.js';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import $ from 'jquery';
+import { later } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 
 export default Controller.extend({
@@ -42,6 +43,10 @@ export default Controller.extend({
       }
     );
 
+    // FIXME: Gross hack - guys, this is real bad...
+    later(() => {
+      $('#user-dropdown-menu').dropdown({ action: 'nothing' });
+    }, 1500);
     // this.set('eventStream', this.getEventStream.call(this));
   },
 

--- a/app/styles/wholetale-dashboard.scss
+++ b/app/styles/wholetale-dashboard.scss
@@ -1508,3 +1508,7 @@ wt.panel .wt.paddleboard.header i {
 .environment-label {
   margin-left: 75px !important;
 }
+
+#user-dropdown-menu {
+  border-bottom: none;
+}

--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -38,10 +38,10 @@
     {{/if}}
     {{#if loggedIn}}
         <div class="right menu">
-            <div class="item wt gravatar-container not-nav">
+            {{!--<div class="item wt gravatar-container not-nav">
                 <img src="{{gravatarUrl}}" class="gravatar" />
             </div>
-            <label class="item small font not-nav">{{user.firstName}} {{user.lastName}}</label>
+            <label class="item small font not-nav">{{user.firstName}} {{user.lastName}}</label>--}}
             {{!-- DEVNOTE: This should be enabled when Job Watcher is working properly
             <a class="item wt thin not-nav" data-tooltip="View running tasks."
                 data-position="bottom right" {{action 'openJobWatcher'}}>
@@ -62,10 +62,27 @@
                     </div>
                 {{/if}}
             </a>
-            <a class="item wt thin not-nav" {{action 'closeMenu' 'logout'}} 
+            {{!--<a class="item wt thin not-nav" {{action 'closeMenu' 'logout'}} 
               data-tooltip="Log out from the Whole Tale." data-position="bottom right">
                 <i class="sign out white large icon"></i>
-            </a>
+            </a>--}}
+            
+            <div id="user-dropdown-menu" class="ui dropdown item wt thin not-nav" style="max-width:unset;">
+                <i class="user white large icon"></i>
+                <div class="menu">
+                  <a class="header item" style="text-align:left;vertical-align:middle;">
+                    <img src="{{gravatarUrl}}" class="ui middle aligned avatar image" />
+                    <span>{{user.firstName}} {{user.lastName}}</span>
+                  </a>
+                  <div class="divider"></div>
+                  {{#link-to 'settings' class="item" activeClass="never-active"}}
+                    <span>Settings</span>
+                  {{/link-to}}
+                  <a class="item" {{action 'logout'}}>
+                    <span>Log Out</span>
+                  </a>
+                </div>
+            </div>
         </div>
         <div class="ember-burger-menu bm-item--push bm--slide right translucent-overlay {{if mobileMenuDisplay 'is-open'}}">
             <div class="bm-menu-container">
@@ -112,18 +129,35 @@
                                 <i class="tasks black icon"></i> {{if showNotificationStream 'Hide' 'Show'}} Notifications
                             </a>
                         </li>
-                        <li class="bm-menu-item">
+                        {{!--<li class="bm-menu-item">
                             <a {{action 'closeMenu' 'logout'}}>
                                 <i class="sign out black icon"></i> Log Out
                             </a>
+                        </li>--}}
+                        <li class="bm-menu-item">
+                            <div class="ui dropdown item">
+                            <i class="user icon"></i>
+                            <i class="dropdown icon"></i>
+                            <div class="menu">
+                              <a class="header item" {{action 'closeMenu'}}>
+                                <div class="wt gravatar-container not-nav">
+                                    <img src="{{gravatarUrl}}" class="gravatar"  style="border-radius: 50%;"/>
+                                </div>
+                                <label>{{user.firstName}} {{user.lastName}}</label>
+                              </a>
+                              <a class="item" {{action 'closeMenu' 'logout'}}>
+                                <i class="sign out black icon"></i> Log Out
+                              </a>
+                            </div>
+                          </div>
                         </li>
                     </ul>
-                    <div style="position: absolute; bottom: 1rem; width: 100%; text-align: center;">
+                    {{!--<div style="position: absolute; bottom: 1rem; width: 100%; text-align: center;">
                         <div class="wt gravatar-container not-nav">
                             <img src="{{gravatarUrl}}" class="gravatar"  style="border-radius: 50%;"/>
                         </div>
                         <label>{{user.firstName}} {{user.lastName}}</label>
-                    </div>
+                    </div>--}}
                 </div>
             </div>
             <div class="bm-outlet">

--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -48,14 +48,14 @@
                     <i class="tasks icon white"></i>
             </a>    
             --}}
-            <a class="item wt thin not-nav" target="_blank"
+            <a class="item wt not-nav" target="_blank"
               href="https://wholetale.readthedocs.io/en/stable/users_guide/index.html"
               data-tooltip="Read the Whole Tale User Guide." data-position="bottom right">
-                <i class="info circle white large icon"></i>
+                <i class="info circle white icon"></i>
             </a>
-            <a class="item wt thin not-nav" target="_blank" {{action 'toggleShowNotifications'}}
+            <a class="item wt not-nav" target="_blank" {{action 'toggleShowNotifications'}}
               href="#" data-tooltip="Show or hide server notifications." data-position="bottom right">
-                <i class="tasks white large icon"></i>
+                <i class="tasks white icon"></i>
                 {{#if (gt notificationStream.events.length 0)}}
                     <div id="event-notification-counter" class="floating ui red label">
                         {{ notificationStream.events.length }}
@@ -67,19 +67,19 @@
                 <i class="sign out white large icon"></i>
             </a>--}}
             
-            <div id="user-dropdown-menu" class="ui dropdown item wt thin not-nav" style="max-width:unset;">
-                <i class="user white large icon"></i>
+            <div id="user-dropdown-menu" class="ui dropdown item wt not-nav">
+                <i class="user circle white icon"></i>
                 <div class="menu">
-                  <a class="header item" style="text-align:left;vertical-align:middle;">
-                    <img src="{{gravatarUrl}}" class="ui middle aligned avatar image" />
+                  <a class="header item nomargin">
+                    <img src="{{gravatarUrl}}" class="gravatar" />
                     <span>{{user.firstName}} {{user.lastName}}</span>
                   </a>
                   <div class="divider"></div>
-                  {{#link-to 'settings' class="item" activeClass="never-active"}}
+                  {{#link-to 'settings' class="item nomargin" activeClass="never-active"}}
                     <span>Settings</span>
                   {{/link-to}}
-                  <a class="item" {{action 'logout'}}>
-                    <span>Log Out</span>
+                  <a class="item nomargin" {{action 'logout'}}>
+                    <span>Log out</span>
                   </a>
                 </div>
             </div>


### PR DESCRIPTION
## Problem
The mockups show a dropdown at the top-right of the navbar, but we currently have separate items. To add upcoming functionality, we should consolidate these navbar options.

Fixes #559 

## Approach
Replace "Logout" and User Gravatar items in the navbar with a more scalable dropdown menu.

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
    * You should see the navbar has a new "user" icon at the top-right
3. Click the "user" icon
    * You should see a dropdown expand
    * The dropdown should contain the user's first/last name and gravatar image
    * The dropdown should provide a link to the Settings page (to be added in a later PR)
    * The dropdown should provide an option to Logout