### PR TITLE
Send 'success' notification upon Tale update. Fixes #566

### DIFF
--- a/app/components/ui/tale-tab-metadata/component.js
+++ b/app/components/ui/tale-tab-metadata/component.js
@@ -17,6 +17,7 @@ const taleStatus = Object.create({
 
 
 export default Component.extend({
+  notificationHandler: service(),
   store: service(),
   apiHost: config.apiHost,
   environments: [],
@@ -148,11 +149,18 @@ export default Component.extend({
         this.send('openErrorModal');
       };
 
+      let notification, notifier = this.get('notificationHandler');
+
       // Only update the Tale if the authors are valid
       if (this.validateAuthors()) {
         this.model.set('authors', this.taleAuthors);
         // Request that the Tale model be updated
-        tale.save().catch(onFail);
+        tale.save()
+          .then(_ => notification={message: "Tale updated", header: "Success"})
+          .catch(onFail)
+          .finally(_ => {
+              if (notification !== null) notifier.pushNotification(notification)
+          });
       }
       else {
         this.send('openErrorModal');


### PR DESCRIPTION
Add a pop-up notification when Tale is updated successfully.

### How to test?
1. Deploy locally.
2. Create a Tale.
3. Click "View" on the Tale.
4. Modify Metadata page, by adding an author.
5. Click Save
6. Observe notification on the right-hand side.