### PR TITLE
Allow user to configure DataONE account from User Settings view

### DIFF
--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -3,6 +3,7 @@ import EmberObject, { computed } from '@ember/object';
 import { A } from '@ember/array';
 import { inject as service } from '@ember/service';
 import { sort } from '@ember/object/computed';
+import config from '../config/environment';
 
 import $ from 'jquery';
 
@@ -26,28 +27,21 @@ export default Controller.extend({
     user: O({}),
     tokens: O({}),
     
-    showConnectExtAccountModal: false,
-    showRevokeExtAccountModal: false,
-    
-    providerTokens: computed('providers', 'tokens', function () {
-      const component = this;
-      const tokens = component.get('tokens');
-      const provider = component.get('tokens');
-      return tokens[provider];
-    }).readOnly(),
-    
     init() {
       this._super(...arguments);
+      this.refreshProviders();
+    },
+    
+    refreshProviders() {
       const component = this;
       
       // Fetch external account providers
       const adapterOptions = { queryParams: { redirect: 'https://dashboard.local.wholetale.org/settings' } };
       component.store.query('account', { adapterOptions }).then(providers => {
         // Of course Ember has their own array implementation... -_-*
-        component.set('providers', providers);
+        component.set('providers', A(providers));
+        component.refreshUserTokens();
       }, err => console.error("Failed to fetch external account providers:", err));
-      
-      this.refreshUserTokens();
     },
     
     refreshUserTokens() {
@@ -56,6 +50,28 @@ export default Controller.extend({
       // Fetch user's configured external tokens
       component.get('userAuth').getCurrentUserFromServer().then(user => {
         component.set('user', user);
+        
+        component.get('providers').forEach(provider => {
+          if (provider.type === 'dataone' && provider.state === 'preauthorized') {
+            let xmlHttp = new XMLHttpRequest();
+        
+            xmlHttp.open("GET", provider.url, false);
+            // Set the response content type
+            xmlHttp.setRequestHeader("Content-Type", "text/xml");
+            // Let XMLHttpRequest know to use cookies
+            xmlHttp.withCredentials = true;
+            xmlHttp.send(null);
+            
+            const data =  xmlHttp.responseText;
+            if (data) {
+              const token = user.otherTokens.find(t => t.provider === provider.name);
+              component.apiCall.authExtToken(provider.name, token.resource_server, data, 'dataone').then(resp => {
+                // Hard reload the page
+                window.location.reload(true);
+              }, err => console.error("Failed to add DataONE API token:", err));
+            }
+          }
+        });
       });
     },
     
@@ -73,9 +89,7 @@ export default Controller.extend({
         component.set('selectedProvider', provider);
         component.apiCall.getExtAccountTargets(provider.name).then(targets => {
           component.get('selectedProvider').set('targets', targets);
-          // TODO: Switch on provider.type to provide a different modal
-          
-          // TODO: pop up a modal for choosing resource_server and entering a new API key
+          // Pop up a modal for choosing resource_server and entering a new API key
           $('#connect-apikey-modal').modal('show');
           $('#newResourceServerDropdown').dropdown();
         }, err => console.error("Failed to fetch provider targets:", err));

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -704,11 +704,18 @@ export default Service.extend({
      * @param providerName The provider for which to create a token
      * @param resourceServer The resource_server associated with this API key
      * @param keyValue The value of the API key to add
+     * @param keyType (optional) either 'dataone' or 'apikey' (apikey is default) 
      */
-    authExtToken(providerName, resourceServer, keyValue) {
+    authExtToken(providerName, resourceServer, keyValue, keyType) {
         return new Promise((resolve, reject) => {
           const token = this.get('tokenHandler').getWholeTaleAuthToken();
           let url = `${config.apiUrl}/account/${providerName}/key?key=${keyValue}&resource_server=${resourceServer}`;
+          
+          if (keyType) {
+              url += `&key_type=${keyType}`;
+          } else {
+              url += `&key_type=apikey`;
+          }
     
           let client = new XMLHttpRequest();
           client.open('POST', url);

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -17,7 +17,6 @@
         <div class="ui segments">
           {{#each sortedProviders as |provider|}}
             <div class="ui segment">
-              {{!-- TODO: Disable when? --}}
               {{#if (or (eq provider.state 'authorized') (eq provider.state 'preauthorized'))}}
                 <button class="ui basic right floated blue button disabled" disabled="true">Connect Account</button>
               {{else if (or (eq provider.type 'bearer') (eq provider.type 'dataone'))}}
@@ -75,7 +74,7 @@
 <div id="connect-apikey-modal" class="ui modal apikey">
   <i class="close icon"></i>
   <div class="header">
-    {{!-- TODO: How to handle article appropriately? (e.g. "a/an ORCID Account") --}}
+    {{!-- TODO: Helper to handle article appropriately? (e.g. "a/an ORCID Account") --}}
     <img class="ui avatar image" src="data:image/png;base64,{{selectedProvider.logo}}"> Connect {{selectedProvider.fullName}} Account
   </div>
   <div class="content">

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -51,7 +51,7 @@
                       <a class="ui right floated disconnect button" {{action 'showConfirmDeleteModal' provider token}}>Disconnect</a>
                       
                       {{!-- TODO: Where do we information on who authorized the connection? --}}
-                      {{#if (and (and (eq provider.type 'apikey') token.resource_server) (eq provider.state 'authorized'))}}
+                      {{#if (and (eq provider.type 'apikey') token.resource_server)}}
                         <p>Authorized on <a href="{{token.resource_server}}" target="_blank">{{token.resource_server}}</a></p>
                       {{else if (eq provider.state 'authorized')}}
                         <p>Authorized</p>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -47,10 +47,8 @@
                 {{#each user.otherTokens as |token|}}
                   {{#if (and token.provider (eq provider.name token.provider))}}
                     <div class="ui basic segment">
-                      {{!-- TODO: Disable when? --}}
                       <a class="ui right floated disconnect button" {{action 'showConfirmDeleteModal' provider token}}>Disconnect</a>
                       
-                      {{!-- TODO: Where do we information on who authorized the connection? --}}
                       {{#if (and (eq provider.type 'apikey') token.resource_server)}}
                         <p>Authorized on <a href="{{token.resource_server}}" target="_blank">{{token.resource_server}}</a></p>
                       {{else if (eq provider.state 'authorized')}}

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -51,10 +51,14 @@
                       <a class="ui right floated disconnect button" {{action 'showConfirmDeleteModal' provider token}}>Disconnect</a>
                       
                       {{!-- TODO: Where do we information on who authorized the connection? --}}
-                      {{#if (and (eq provider.type 'apikey') token.resource_server)}}
+                      {{#if (and (and (eq provider.type 'apikey') token.resource_server) (eq provider.state 'authorized'))}}
                         <p>Authorized on <a href="{{token.resource_server}}" target="_blank">{{token.resource_server}}</a></p>
-                      {{else}}
+                      {{else if (eq provider.state 'authorized')}}
                         <p>Authorized</p>
+                      {{else if (eq provider.state 'preauthorized')}}
+                        <p>Preauthorized</p>
+                      {{else}}
+                        <p>Unknown</p>
                       {{/if}}
                     </div>
                   {{/if}}


### PR DESCRIPTION
## Problem
Following #563, DataONE accounts are not properly `authorized` from the dashboard. The ORCID login leaves the DataONE in a `preauthorized` state, and never finishes the authorization process by POSTing the DataONE JWT back to the server.

Fixes #573 

## Approach
Fetch and POST the DataONE JWT back to the server when a DataONe provider is detected in a `preauthorized` state.

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Settings view
4. Disconnect any DataONE account(s) present
5. Beside DataONE, click "Connect Account" to login via ORCID
    * `preauthorized` - you should be taken to the ORCID login page, then back to the settings view
6. After 1-2 seconds, the view should update without refreshing
    * `authorized` - you should still be on the settings view