### PR TITLE
Display repository name instead of URL in publish-modal

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -234,7 +234,8 @@ export default Component.extend(FullScreenMixin, {
         this.set('publishStatus', 'initialized');
         this.set('progress', 0);
         
-        return this.apiCall.getRepositories().then(repos => {
+        let adapterOptions = {};
+        return this.store.query('repository', adapterOptions).then(repos => {
           this.set('repositories', A(repos));
           if (repos.length > 0) {
             this.set('selectedRepository', this.get('repositories')[0]);
@@ -397,14 +398,14 @@ export default Component.extend(FullScreenMixin, {
         submitPublish() {
             const self = this;
 
-            let repository = this.selectedRepository;
+            let selection = this.selectedRepository;
 
             self.set('publishStatus', 'in_progress');
             self.set('progress', 0);
             const tale = self.get('model');
 
             // Call the publish endpoint
-            self.get("apiCall").publishTale(tale._id, repository)
+            self.get("apiCall").publishTale(tale._id, selection.repository)
                 .then((publishJob) => {
                     console.log('Submitted for publish:', publishJob);
                     self.set('publishStatus', 'in_progress');
@@ -451,9 +452,12 @@ export default Component.extend(FullScreenMixin, {
         */
         onRepositoryChange: function () {
           let repositoryName = $('.repository.selection.dropdown.ui.dropdown').dropdown('get text');
-          console.log('Selected '+ repositoryName + ' for publishing');
-          let repository = this.get('repositories').find((repo) => repo === repositoryName);
-          this.set('selectedRepository', repository);
+          let selection = this.get('repositories').find((repo) => repo.name === repositoryName);
+          if (selection) {
+            this.set('selectedRepository', selection);
+          } else {
+            console.error('Failed to select '+ repositoryName + ' for publishing');
+          }
         },
     }
 });

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -147,7 +147,7 @@
                 <div class="menu">
                     {{#each repositories as |repo|}}
                     <div class="item">
-                        {{repo}}
+                        {{repo.name}}
                     </div>
                     {{/each}}
                 </div>
@@ -163,7 +163,7 @@
           <div class="ui blue message progress-area" id="publishing-progress-message">
             <p class="header publishing-now">
                 <a id="publishing-success-label" class="ui blue label">IN PROGRESS</a>
-                Your Tale is being published to {{selectedRepository}}
+                Your Tale is being published to {{selectedRepository.name}}
             </p>
             <div class="publish-progressbar">
                 {{#ui-progress progress=progress value=progress total=progressTotal class="teal indicating"}}

--- a/app/models/custom-inflector-rules.js
+++ b/app/models/custom-inflector-rules.js
@@ -19,6 +19,7 @@ inflector.uncountable('job');
 inflector.uncountable('dm');
 inflector.uncountable('workspace');
 inflector.uncountable('account');
+inflector.uncountable('repository');
 
 // Meet Ember Inspector's expectation of an export
 export default {};

--- a/app/models/repository.js
+++ b/app/models/repository.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  "name": DS.attr('string'),
+  "repository": DS.attr('string'),
+});

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -436,7 +436,7 @@ export default Service.extend({
      * Publishes a Tale to DataONE
      * @method publishTale
      * @param taleId The ID of the Tale this is being published
-     * @param repository the repo to which we should publish 
+     * @param repoUrl the url of the publish destination repository
      */
   publishTale(taleId, repoUrl) {
       const token = this.get('tokenHandler').getWholeTaleAuthToken();

--- a/app/services/api-call.js
+++ b/app/services/api-call.js
@@ -438,13 +438,11 @@ export default Service.extend({
      * @param taleId The ID of the Tale this is being published
      * @param repository the repo to which we should publish 
      */
-  publishTale(taleId, repository) {
+  publishTale(taleId, repoUrl) {
       const token = this.get('tokenHandler').getWholeTaleAuthToken();
       return new Promise ((resolve, reject) => {
-          let url = `${config.apiUrl}/tale/${taleId}/publish?repository=${repository}`;
-    
           let client = new XMLHttpRequest();
-          client.open('PUT', url);
+          client.open('PUT', `${config.apiUrl}/tale/${taleId}/publish?repository=${encodeURIComponent(repoUrl)}`);
           client.setRequestHeader("Girder-Token", token);
     
           client.addEventListener("load", function() {
@@ -756,25 +754,6 @@ export default Service.extend({
           });
           client.addEventListener("error", reject);
           client.send();
-        });
-    },
-    
-
-    /**
-     * Fetch a list of all currently configured external repositories.
-     * @method getRepositories
-     */
-    getRepositories() {
-        // XXX: Ember-Data cannot handle models that are simply strings.
-        return $.ajax({
-            url: `${config.apiUrl}/repository`,
-            method: 'GET',
-            headers: {
-                'Girder-Token': this.get('tokenHandler').getWholeTaleAuthToken()
-            },
-            dataType: 'json',
-            contentType: 'application/json',
-            timeout: 3000, // ms
         });
     },
   


### PR DESCRIPTION
## Problem
Our publish-modal only lists a raw URL for the destination repository. It would be nice to display a more friendly or human-readable name for each entry.

Fixes #577

The backend work needed to handle this change is already done: https://github.com/whole-tale/girder_wholetale/pull/375

## Approach
* Add a new `repository` model, containing a `name` and `repository` url as strings
* Update the publish-modal to use the new `repository` model

## How to Test
Prerequisite: run alongside https://github.com/whole-tale/girder_wholetale/pull/375, or wait for it to be merged

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Settings view
4. Connect accounts for DataONE and Zenodo Sandbox
5. Create a Tale, if you haven't already (you don't need to run it)
6. Navigate to the Run view for the Tale, expand the dropdown at the top right, and choose "Publish Tale"
    * The publish-modal should open
7. Choose "DataONE Dev" from the dropdown and click "Publish" at the bottom-right
    * Publishing should complete successfully
8. Choose "Zenodo Sandbox" from the dropdown and click "Publish" at the bottom-right
    * Publishing should complete successfully