### PR TITLE
Add explicit user selection for asTale parameter

### DIFF
--- a/app/components/ui/create-tale-modal/component.js
+++ b/app/components/ui/create-tale-modal/component.js
@@ -98,8 +98,7 @@ export default Component.extend({
           // asTale defaults to false; it will only be set to true if query param 
           // is present and some form of the string "True" (case insensistive)
           if (asTale && asTale.toLowerCase() === "true") {
-            this.set('asTale', true);
-            $('#as-tale-true-chkbox').checkbox('check');
+            later(() => $('#as-tale-true-chkbox').checkbox('check'), 500);
           }
 
           let {official, nonOfficial} = this.computeEnvironments;

--- a/app/components/ui/create-tale-modal/component.js
+++ b/app/components/ui/create-tale-modal/component.js
@@ -31,13 +31,11 @@ export default Component.extend({
     const component = this;
     $('#as-tale-false-chkbox').checkbox({
       onChecked: function() {
-        console.log('Toggling asTale to false');
         component.set('asTale', false);
       }
     });
     $('#as-tale-true-chkbox').checkbox({
       onChecked: function() {
-        console.log('Toggling asTale to true');
         component.set('asTale', true);
       }
     });

--- a/app/components/ui/create-tale-modal/component.js
+++ b/app/components/ui/create-tale-modal/component.js
@@ -99,6 +99,7 @@ export default Component.extend({
           // is present and some form of the string "True" (case insensistive)
           if (asTale && asTale.toLowerCase() === "true") {
             this.set('asTale', true);
+            $('#as-tale-true-chkbox').checkbox('check');
           }
 
           let {official, nonOfficial} = this.computeEnvironments;
@@ -113,7 +114,7 @@ export default Component.extend({
           this.set('datasetAPI', api);
         }
       } catch(e) {
-        this.handleError({responseJSON:{message:e+""}});
+        this.handleError(e);
       }
     },
 
@@ -218,7 +219,7 @@ export default Component.extend({
     newTaleImport.save({adapterOptions}).then((tale) => {
       self.onTaleCreateSuccess(tale);
     }).catch(e => {
-      self.handleError({responseJSON:{message:e+""}});
+      self.handleError(e);
     });
   },
   

--- a/app/components/ui/create-tale-modal/component.js
+++ b/app/components/ui/create-tale-modal/component.js
@@ -14,7 +14,8 @@ export default Component.extend({
   dataSet: null,
   config: null,
   asTale: false,
-
+  asTaleEnabled: true,
+  
   createAndLaunch: true,
   createButtonText: computed('createAndLaunch', function() {
     return this.get('createAndLaunch') ? 'Create New Tale and Launch' : 'Create New Tale';
@@ -25,9 +26,26 @@ export default Component.extend({
   }),
   
   defaultErrorMessage: "There was an error while creating your Tale.",
+  
+  didRender() {
+    const component = this;
+    $('#as-tale-false-chkbox').checkbox({
+      onChecked: function() {
+        console.log('Toggling asTale to false');
+        component.set('asTale', false);
+      }
+    });
+    $('#as-tale-true-chkbox').checkbox({
+      onChecked: function() {
+        console.log('Toggling asTale to true');
+        component.set('asTale', true);
+      }
+    });
+  },
 
   // ---------------------------------------------------------------------------------
   // ACTIONS TOC:
+  //   toggleAsTale(newValue) = Event: onChange when clicking radio buttons during import
   //   createNewTaleButton() = Event: onClick "Create New Tale" button
   //   clearModal()          = Event: onHide modal 
   //   setModalFromQueryParams() = Event: onShow modal

--- a/app/components/ui/create-tale-modal/template.hbs
+++ b/app/components/ui/create-tale-modal/template.hbs
@@ -51,6 +51,30 @@
       <div class="twelve wide column">
       {{#if importing}}
         <p style="font-style:italic;margin-top:5px;font-weight:200">Data Source: {{dataSet}}</p>
+        
+        <div class="grouped fields">
+          <div class="field">
+            <div id="as-tale-false-chkbox" class="ui radio checkbox">
+              <input type="radio" name="asTale" id="as-tale-false" value="false" checked="checked" />
+              <label for="as-tale-false">
+                <b>READ ONLY</b> <i>recommended</i> — Treat as source dataset for analysis
+                <a href="http://docs.wholetale.org/en/stable/users_guide/compose.html"
+                    style="margin-left:.75rem;font-style:italic" target="_blank">
+                  Why would I do this?
+                </a>
+              </label>
+            </div>
+          </div>
+
+          <div class="field">
+            <div id="as-tale-true-chkbox" class="ui radio checkbox">
+              <input type="radio" name="asTale" id="as-tale-true" value="true" />
+              <label for="as-tale-true">
+                <b>READ/WRITE</b> — Enable data editing
+              </label>
+            </div>
+          </div>
+        </div>
       {{else}}
         <p style="font-style:italic;margin-top:5px;color:#999">Add data after Tale creation using your chosen compute environment, or the Files tab of your running Tale.</p>
       {{/if}}


### PR DESCRIPTION
## Problem
In the "Analyze in WT" case, there is no explicit option for the user to declare that they want to import their Data Source as a Tale. The only way to toggle this flag is by using the URL query-string parameter, which is not very user-friendly.

FIxes #579 

## Approach
Per the mockups, add a set of Radio buttons to the "Analyze in WT" / "import" case on the `create-tale-modal`. The first radio (default) set `asTale` to false, while the second sets `asTale` to true.

There is also an option to disable the second radio button, although it is not clear under what circumstances this may be useful.

## How to Test
Preconditions: shut down any running instances

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to https://dashboard.local.wholetale.org/browse?uri=https%3A%2F%2Fdev2.dataverse.org%2Fdataset.xhtml%3FpersistentId%3Ddoi%3A10.5072%2FFK2%2FC074IQ&name=Dataverse%20IRC%20Metrics&environment=Jupyter%20Classic
    * You should see the `create-tale-modal` pop up automatically after the page loads
    * You should see that `Dataverse IRC Metrics` is automatically entered as the `name`
    * You should see that `Jupyter Classic` is automatically chosen as the `environment`
    * You should see that the Dataverse DOI/URI is listed as the `Data Source`
    * You should see the newly-offered radio buttons appear at the bottom of the modal
    * You should see that `READ ONLY` is selected by default - this is `asTale=false`
4. Open the Networks tab in your Development Console, then submit the form
    * You should see that a `POST /tale/import` was sent with `asTale=false` in the query-string
    * You should be navigated to the Run view for the now-launching Tale
5. Navigate to Run > Files > External Data
    * You should see `Dataverse IRC Metrics` listed here as an immutable external dataset
6. Now, navigate to https://dashboard.local.wholetale.org/browse?uri=https%3A%2F%2Fdev2.dataverse.org%2Fdataset.xhtml%3FpersistentId%3Ddoi%3A10.5072%2FFK2%2FC074IQ&name=Dataverse%20IRC%20Metrics&environment=Jupyter%20Classic&asTale=true
    * You should see the `create-tale-modal` pop up automatically after the page loads
    * You should see that `Dataverse IRC Metrics` is automatically entered as the `name`
    * You should see that `Jupyter Classic` is automatically chosen as the `environment`
    * You should see that the Dataverse DOI/URI is listed as the `Data Source`
    * You should see the newly-offered radio buttons appear at the bottom of the modal
    * You should see that `READ/WRITE` is now selected by default - this is `asTale=true` as specified in the query string
7. Open the Networks tab in your Development Console, then submit the form
    * You should see that a `POST /tale/import` was sent with `asTale=true` in the query-string
    * You should be navigated to the Run view for the now-launching Tale
8. Navigate to Run > Files > Tale Workspace
    * You should see the contents of `Dataverse IRC Metrics` has been imported into your editable Tale Workspace