### PR TITLE
Interpret resource_server as absolute URL

### DIFF
--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -49,7 +49,7 @@
                       <a class="ui right floated disconnect button" {{action 'showConfirmDeleteModal' provider token}}>Disconnect</a>
                       
                       {{#if (and (eq provider.type 'apikey') token.resource_server)}}
-                        <p>Authorized on <a href="{{token.resource_server}}" target="_blank">{{token.resource_server}}</a></p>
+                        <p>Authorized on <a href="//{{token.resource_server}}" target="_blank">{{token.resource_server}}</a></p>
                       {{else if (eq provider.state 'authorized')}}
                         <p>Authorized</p>
                       {{else if (eq provider.state 'preauthorized')}}


### PR DESCRIPTION
## Problem
The "User Settings" view offers users a way to connect external API tokens to their account for consumption and integration within WholeTale. After authorizing a provider with a particular resource_server value, the UI is supposed to offer a link to that resource_server.

Unfortunately, since the resource_server values received from Girder do not include a protocol, the browser interprets them as a relative path, and appends them to the end of the dashboard URL.

Fixes #581 

## Approach
Prepend link with `//` to force browser to interpret `resource_server` as an absolute URL.

Note that we use `//` to avoid potential Mixed-Content errors between HTTPS and HTTP.

See https://superuser.com/questions/341301/why-does-instead-of-http-or-https-before-the-actual-link-work

## How to Test
1. Checkout and run this code locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the "User Settings" view
4. Connect a Dataverse or Zenodo account, if you haven't already
    * You should see "Authorized on _________" appear below the Dataverse or Zenodo provider, where ________ is a link to the `resource_server` 
5. Click the on the link offered by the "Authorized on _________" line
    * Your browser should open a new tab to `https://demo.dataverse.org` or `https://sandbox.zenodo.org`