### PR TITLE
Add 'Settings' link to the mobile header/menu

### DIFF
--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -111,7 +111,7 @@
                         </li>--}}
                         <li class="bm-menu-item">
                             {{#link-to 'manage' invokeAction=(action 'closeMenu' 'Manage' 'upload')}}
-                                <i class="cog black icon"></i> Manage
+                                <i class="hdd black icon"></i> Manage
                             {{/link-to}}
                         </li>
                         {{!-- <li class="bm-menu-item">
@@ -119,6 +119,12 @@
                                 <i class="edit black icon"></i> Compose
                             {{/link-to}}
                         </li> --}}
+                  
+                        <li class="bm-menu-item">
+                            {{#link-to 'settings' invokeAction=(action 'closeMenu' 'Settings' 'upload')}}
+                                <i class="cog black icon"></i> Settings
+                            {{/link-to}}
+                        </li>
                         <li class="bm-menu-item">
                             <a href="https://wholetale.readthedocs.io/en/stable/users_guide/index.html" target="_blank">
                                 <i class="info circle black icon"></i> User Guide

--- a/app/templates/common/header.hbs
+++ b/app/templates/common/header.hbs
@@ -135,11 +135,11 @@
                                 <i class="tasks black icon"></i> {{if showNotificationStream 'Hide' 'Show'}} Notifications
                             </a>
                         </li>
-                        {{!--<li class="bm-menu-item">
+                        <li class="bm-menu-item">
                             <a {{action 'closeMenu' 'logout'}}>
                                 <i class="sign out black icon"></i> Log Out
                             </a>
-                        </li>--}}
+                        </li>
                         <li class="bm-menu-item">
                             <div class="ui dropdown item">
                             <i class="user icon"></i>


### PR DESCRIPTION
## Problem
The mobile-only navbar/menu of the WholeTale Dashboard does not include a link to the new "Settings" view. This can also be seen by resizing a desktop browser window to be sufficiently small.

Fixes #584

## Approach
Update the mobile menu to include the missing link.

Also, I went ahead and changed the Manage icon from `cog` to `hdd`, as `cog` seems more suitable for a settings/preferences view.

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3a. On Mobile: Look at the top navbar
3b. On Desktop: Resize your browser window to about half of your screen size
    * You should see a single "stacked horizontal bars" or "hamburger" icon at the top-right
4. Click the "hamburger" icon
    * You should see a slide-out menu appear from the right
    * You should see a link to "Settings" now appears in the list
    * You should see that the link to "Manage" now uses the `hdd` icon
5. Click the "Settings" link in the menu
    * You should be brought to the new "User Settings" view