### PR TITLE
Fixed hard-coded dashboard.local link in provider redirect

### DIFF
--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -36,7 +36,7 @@ export default Controller.extend({
       const component = this;
       
       // Fetch external account providers
-      const adapterOptions = { queryParams: { redirect: 'https://dashboard.local.wholetale.org/settings' } };
+      const adapterOptions = { queryParams: { redirect: config.wholeTaleHost + '/settings' } };
       component.store.query('account', { adapterOptions }).then(providers => {
         // Of course Ember has their own array implementation... -_-*
         component.set('providers', A(providers));


### PR DESCRIPTION
## Problem
A hard-coded value for `https://dashboard.local.wholetale.org/settings` was left in the controller for the User Settings view. This obviously will not work in production.

## Approach
Replace the hard-coded hostname with `config.wholeTaleHost` instead. This value is populated from an environment variable using `sed` when the Ember dashboard is built.

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the "User Settings" view
4. Connect an OAuth or DataONE provider
    * After authenticating/authorizing, you should be redirected back to the dashboard