### PR TITLE
Check for e.message in Create New Tale Modal

### DIFF
--- a/app/components/ui/create-tale-modal/component.js
+++ b/app/components/ui/create-tale-modal/component.js
@@ -98,17 +98,17 @@ export default Component.extend({
           if (asTale && asTale.toLowerCase() === "true") {
             later(() => $('#as-tale-true-chkbox').checkbox('check'), 500);
           }
-
+          this.set('datasetAPI', api);
+          
           let {official, nonOfficial} = this.computeEnvironments;
           let image = official.findBy('name', environment) || nonOfficial.findBy('name', environment);
-          if (!image && environment) throw new Error('Could not find specified environment: '+environment);
-
+          if (!image && environment) {
+            throw new Error('Could not find specified environment: '+environment);
+          }
           if (image) {
             this.set('imageId', image.id);
             $('.ui.dropdown.compute-environment').dropdown('set selected', image.id);
           }
-
-          this.set('datasetAPI', api);
         }
       } catch(e) {
         this.handleError(e);
@@ -161,8 +161,12 @@ export default Component.extend({
   // Display error message
   // ---------------------------------------------------------------------------------
   handleError(e) {
+    if (e.message) {
+      this.set('errorMessage', e.message);
+    } else{
     let errorMessage = (e.responseJSON ? e.responseJSON.message : this.get('defaultErrorMessage'));
     this.set('errorMessage', errorMessage);
+    }
   },
 
   // ---------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/whole-tale/dashboard/issues/585 and https://github.com/whole-tale/dashboard/issues/524

I originally had this as a fix for 585 but realized the root issue is that girder will send errors back as `e.message`. Checking for this gets us the desired message.

Note that the error message isn't removed when the user selects an environment. We don't know what kind of error we get back, so we have no way to know when to clear the error message. For example, we wouldn't want to clear an authentication error when the user selects a valid environment.


To Test:
1. Deploy locally
1. Make sure you have 2 Tales running
1. Visit https://dashboard.local.wholetale.org/browse?uri=https%3A%2F%2Fdoi.org%2F10.5281%2Fzenodo.1215988&name=weecology%2FPortalData&environment=XXX
1. Note that you see an error about the environment not found
1. Pick an environment
1. Also note that you can still interact with the modal
1. Create and launch the Tale
1. See the notification about having two instances