### PR TITLE
Display copy + launch errors

### DIFF
--- a/app/components/ui/copy-on-launch-modal/component.js
+++ b/app/components/ui/copy-on-launch-modal/component.js
@@ -1,7 +1,5 @@
 import Component from '@ember/component';
 import EmberObject from '@ember/object';
-import { A } from '@ember/array';
-import { later } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import $ from 'jquery';
 import layout from './template';
@@ -48,51 +46,5 @@ export default Component.extend({
             });
           }
         },
-                
-                
-                
-                // Dead code: 
-                
-                
-                
-                
-                /*
-              self.set('copyingTale', false);
-              self.actions.closeCopyOnLaunchModal.call(self);
-              
-              // Convert JSON response to an EmberObject
-              let eTaleCopy = EmberObject.create(taleCopy);
-              
-              // Push to models in view
-              // TODO: Detect filtered view?
-              const tales = self.get('modelsInView');
-              if (tales) {
-                  tales.pushObject(eTaleCopy);
-                  self.set('modelsInView', A(tales));
-              }
-              
-              // Reset state manually when re-launching
-              eTaleCopy.set('launchError', null);
-              eTaleCopy.set('launchStatus', 'starting');
-              eTaleCopy.set('launchResetRequest', null);
-          
-                
-              
-              // Launch the newly-copied tale
-              return self.apiCall.startTale(eTaleCopy).then((instance) => {
-                eTaleCopy.set('instance', instance);
-                self.apiCall.waitForInstance(instance).then((instance) => {
-                    eTaleCopy.set('instance', instance);
-                    self.get('taleLaunched')();
-                    eTaleCopy.set('launchError', null);
-                    eTaleCopy.set('launchStatus', 'started');
-                    console.log('Tale is now started:', eTaleCopy);
-                    resetStatusAfterMs(eTaleCopy, 10000);
-                  }).catch((err) => handleLaunchError(eTaleCopy, err));
-              }).catch((err) => handleLaunchError(eTaleCopy, err));
-            });
-          } else {
-            console.log('No tale to copy... something went wrong!');
-          }*/
     }
 });

--- a/app/components/ui/copy-on-launch-modal/component.js
+++ b/app/components/ui/copy-on-launch-modal/component.js
@@ -11,9 +11,8 @@ export default Component.extend({
     store: service(),
     apiCall: service('api-call'),
     router: service(),
-    
+    errorMessage: "",
     taleToCopy: null,
-
 
     actions: {
         closeCopyOnLaunchModal() {
@@ -32,11 +31,9 @@ export default Component.extend({
           if (originalTale) {
               
               let handleLaunchError = (tale, err) => {
-                // deal with the failure here
-                //tale.set('launchStatus', 'error');
-                //tale.set('launchError', err.message || err);
-                
                 console.error('Failed to launch Tale', err);
+                self.set("errorMessage", err.message);
+                $('.ui.modal.compose-error').modal('show');
               };
               
             self.get('apiCall').copyTale(originalTale).then(taleCopy => {

--- a/app/components/ui/copy-on-launch-modal/template.hbs
+++ b/app/components/ui/copy-on-launch-modal/template.hbs
@@ -21,3 +21,19 @@
     </div>
   </div>
 </div>
+
+<div class="ui copy-error modal">
+    <div class="header">
+        Tale Error
+    </div>
+    <div class="image content">
+        <div class="description">
+            <p>{{errorMessage}}</p>
+        </div>
+    </div>
+    <div class="actions">
+        <div class="ui black deny button">
+            Close
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This PR adds a modal dialog that opens when copy + launching fails. This fixes the issue where the user wasn't getting a notification that they already had two instances running. Fixes #522 

![WGdUlAuBXw](https://user-images.githubusercontent.com/9289652/74384223-b2a01680-4da5-11ea-9746-889210304ff6.gif)


To Test:
1. Deploy this branch
2. Launch two instances
3. Attempt to copy + launch a Tale you don't own
4. See the error notification