### PR TITLE
Disable Create New Tale button when clicked once

### DIFF
--- a/app/components/ui/create-tale-modal/component.js
+++ b/app/components/ui/create-tale-modal/component.js
@@ -15,14 +15,15 @@ export default Component.extend({
   config: null,
   asTale: false,
   asTaleEnabled: true,
-  
+  creatingTale: false,
   createAndLaunch: true,
   createButtonText: computed('createAndLaunch', function() {
     return this.get('createAndLaunch') ? 'Create New Tale and Launch' : 'Create New Tale';
   }),
 
-  disabled: computed('title', 'imageId', function() {
-    return (this.get('title') && this.get('imageId')) ? '' : 'disabled';
+  disabled: computed('title', 'imageId', 'creatingTale', function() {
+    let validTextFields = (this.get('title') && this.get('imageId')) ? true : false;
+    return (validTextFields && !this.get('creatingTale')) ? '': 'disabled';
   }),
   
   defaultErrorMessage: "There was an error while creating your Tale.",
@@ -58,6 +59,7 @@ export default Component.extend({
 
       title = title.trim();
 
+      this.set("creatingTale", true);
       if (this.importing) {
         this.importTaleFromDataset(title, imageId, dataSet||[], datasetAPI, asTale);
       } else {
@@ -146,6 +148,7 @@ export default Component.extend({
   // ---------------------------------------------------------------------------------
   handleLaunchError(e) {
     const self = this;
+    self.set("creatingTale", false);
     self.handleError(e);
     $('.ui.modal.compose-error').modal('show');
     $('.ui.modal.compose-error').modal({


### PR DESCRIPTION
Fixes issue #587

I added a property to the component that gets set to 'true' when the user clicks the create button, and back to 'false' if there's an error in case they need to click it again. I modified the computed property that dictates enabled/disabled so that it takes this new property into account.

To Test:
1. Deploy this branch
2. Open the create new tale modal
3. Confirm that the create button is only enabled once you enter a title and environment
4. Click create new tale (and launch if you want)
5. Note that the button disables before the modal closes
6. Re-open the modal, note that the state is reset