### PR TITLE
Add related identifiers to Tale's metadata page

### DIFF
--- a/app/components/ui/tale-tab-metadata/component.js
+++ b/app/components/ui/tale-tab-metadata/component.js
@@ -42,6 +42,35 @@ export default Component.extend({
     return null;
   }),
 
+  relatedIdentifiers: computed('model', 'model.relatedIdentifiers', function() {
+    const tale = this.get('model');
+    console.log(tale.relatedIdentifiers);
+    if (tale.relatedIdentifiers && tale.relatedIdentifiers.length) {
+       return tale.relatedIdentifiers.map((id) => {
+          // Convert camelCase to sentence starting with upper case
+          var relation = id.relation.split(/(?=[A-Z])/).join(" ").toLowerCase();
+          relation = relation.charAt(0).toUpperCase() + relation.slice(1);
+
+          // Derive a href from type of id
+          if (id.identifier.startsWith("doi")) {
+              var link = "https://dx.doi.org/" + id.identifier;
+          } else if (id.identifier.startsWith("urn")) {
+              var link = null;
+          } else {
+              var link = id.identifier;
+          }
+
+          // Return all data require to create a nice list in the template
+          return {
+              relation: relation,
+              identifier: id.identifier,
+              link: link
+          }
+       });
+    }
+    return null;
+  }),
+
   init() {
     this._super(...arguments);
     

--- a/app/components/ui/tale-tab-metadata/component.js
+++ b/app/components/ui/tale-tab-metadata/component.js
@@ -52,12 +52,11 @@ export default Component.extend({
           relation = relation.charAt(0).toUpperCase() + relation.slice(1);
 
           // Derive a href from type of id
+          let link = id.identifier;
           if (id.identifier.startsWith("doi")) {
-              var link = "https://dx.doi.org/" + id.identifier;
+              link = "https://dx.doi.org/" + id.identifier;
           } else if (id.identifier.startsWith("urn")) {
-              var link = null;
-          } else {
-              var link = id.identifier;
+              link = null;
           }
 
           // Return all data require to create a nice list in the template

--- a/app/components/ui/tale-tab-metadata/component.js
+++ b/app/components/ui/tale-tab-metadata/component.js
@@ -48,7 +48,7 @@ export default Component.extend({
     if (tale.relatedIdentifiers && tale.relatedIdentifiers.length) {
        return tale.relatedIdentifiers.map((id) => {
           // Convert camelCase to sentence starting with upper case
-          var relation = id.relation.split(/(?=[A-Z])/).join(" ").toLowerCase();
+          let relation = id.relation.split(/(?=[A-Z])/).join(" ").toLowerCase();
           relation = relation.charAt(0).toUpperCase() + relation.slice(1);
 
           // Derive a href from type of id

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -160,7 +160,7 @@
                 <div class="ui list">
                 {{#each relatedIdentifiers as |id|}}
                     {{#if id.link}}
-                        <div class="item">{{id.relation}} <a href={{id.link}}>{{id.identifier}}</a></div>
+                        <div class="item">{{id.relation}} <a target="_blank" href={{id.link}}>{{id.identifier}}</a></div>
                     {{else}}
                         <div class="item">{{id.relation}} {{id.identifier}}</div>
                     {{/if}}
@@ -197,4 +197,3 @@
         </div>
     </div>
 </div>
-

--- a/app/components/ui/tale-tab-metadata/template.hbs
+++ b/app/components/ui/tale-tab-metadata/template.hbs
@@ -153,7 +153,24 @@
             {{/if}}
         </div>
     </div>
-
+    <div class="inline fields ui grid">
+        <label class="two wide column right aligned">Related Identifiers</label>
+        <div class="ui action field thirteen wide column">
+            {{#if relatedIdentifiers}}
+                <div class="ui list">
+                {{#each relatedIdentifiers as |id|}}
+                    {{#if id.link}}
+                        <div class="item">{{id.relation}} <a href={{id.link}}>{{id.identifier}}</a></div>
+                    {{else}}
+                        <div class="item">{{id.relation}} {{id.identifier}}</div>
+                    {{/if}}
+                {{/each}}
+                </div>
+            {{else}}
+                <span>This Tale has no related identifiers</span>
+            {{/if}}
+        </div>
+    </div>
     <div class="inline fields ui grid">
         <label class="two wide column right aligned"></label>
         <div class="field two wide right aligned column">

--- a/app/models/tale.js
+++ b/app/models/tale.js
@@ -20,6 +20,7 @@ export default DS.Model.extend({
   "updated": DS.attr('date'),
   "dataSet": DS.attr(),
   "dataSetCitation": DS.attr(),
+  "relatedIdentifiers": DS.attr(),
   "folderId": DS.attr('string'),
   "licenseSPDX": DS.attr('string')
 });


### PR DESCRIPTION
This PR complements https://github.com/whole-tale/girder_wholetale/pull/391 by adding related identifiers field to Tale's metadata page.

### How to test?
1. Deploy this along with https://github.com/whole-tale/girder_wholetale/pull/391
1. Create a Tale (no need to launch) by following [this link](https://dashboard.local.wholetale.org/browse?uri=https%3A%2F%2Fdataverse.harvard.edu%2Fdataset.xhtml%3FpersistentId%3Ddoi%3A10.7910%2FDVN%2F3MJ7IR&asTale=True&name=Replication+Data+for%3A+%22Agricultural+Fires+and+Health+at+Birth%22)  (choose RW for data)
1. Tale metadata should contain "Is derived from [doi:10.7910/DVN/3MJ7IR](https://dx.doi.org/doi:10.7910/DVN/3MJ7IR)". Follow the link and see if it resolves
1. (optionally). Modify Tale's metadata using swagger API page by adding:

  ```json
   "relatedIdentifiers": [
      {
        "identifier": "doi:10.7910/DVN/3MJ7IR",
        "relation": "IsDerivedFrom"
      },
      {
        "identifier": "urn:some_urn",
        "relation": "Cites"
      },
      {
        "identifier": "https://wholetale.org",
        "relation": "IsIdenticalTo"
      }
    ],
  ```
 
5. (optionally) Verify that Tale's metadata now shows a nice list for `related identifiers`. Verify that https://wholetale.org resolves.

![relids](https://user-images.githubusercontent.com/352673/74682917-08513600-518d-11ea-9aa4-a566c991537f.png)
