### PR TITLE
Misc file upload fixes

### DIFF
--- a/app/components/ui/files/nice-dropzone/component.js
+++ b/app/components/ui/files/nice-dropzone/component.js
@@ -182,7 +182,7 @@ export default Ember.Component.extend({
   },
 
   error(file, errorMessage) {
-    file.error = errorMessage;
+    file.error = errorMessage.message;
     this.uploadProgress(file);
   },
 

--- a/app/components/ui/files/nice-dropzone/template.hbs
+++ b/app/components/ui/files/nice-dropzone/template.hbs
@@ -5,7 +5,7 @@
         <button class="ui mini right floated button" {{action 'cancelUploads'}}>Cancel</button>
     {{/unless}}
     <div class="ui header" style="color:whitesmoke; margin-bottom: 10px">File Uploads</div>
-    <ul style="list-style-type:square">
+    <ul style="list-style-type:square;overflow-y:scroll;max-height:650px;">
     {{#each files as |file|}}
         {{#if (eq file.status "error")}}
             <li style="margin-bottom: 5px;"><i class="red warning icon"></i>


### PR DESCRIPTION
I had to do some file uploads today and I ran across #464 and #496. This PR has two quick one-line fixes for each one.

Fixes #464
Fixes #496 

Demo of the overflow: https://recordit.co/F75IozP2xv

To Test:
1. Check the branch out
2. Deploy
3. Navigate to a tale you own
4. Upload many files to the workspace
5. Note that the file box is now restricted and you can scroll (See demo)
6. Upload a file with 0 bytes inside
7. Note that you no longer see the javascript object (object object), but an error instead