### PR TITLE
Remember the state of filters on Browse view

### DIFF
--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -17,7 +17,7 @@ export default Component.extend({
   taleInstanceName: "",
   filteredSet: A(),
   filters: ['All', 'Mine', 'Published', 'Recent'],
-  filter: window.localStorage.getItem('browse::filter') || 'All',
+  filter: 'All',
   numberOfModels: 0,
   pageNumber: 1,
   totalPages: 1,
@@ -92,7 +92,11 @@ export default Component.extend({
     component.set('searchView', models.tales);
     component.updateModels(component, models.tales);
     component.set('addButtonLogo', '/icons/plus-sign.png');
-    component.setFilter();
+    
+    const filter = window.localStorage.getItem('browse::filter');
+    if (filter) {
+      this.actions.selectFilter.call(component, filter);
+    }
     
     // Check if any instance is LAUNCHING
     component.get('store').findAll('instance').then(instances => {

--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -17,7 +17,7 @@ export default Component.extend({
   taleInstanceName: "",
   filteredSet: A(),
   filters: ['All', 'Mine', 'Published', 'Recent'],
-  filter: 'All',
+  filter: window.localStorage.getItem('browse::filter') || 'All',
   numberOfModels: 0,
   pageNumber: 1,
   totalPages: 1,
@@ -121,15 +121,19 @@ export default Component.extend({
     this.set('loadingTales', true);
 
     if (filter === 'All') {
+      window.localStorage.setItem('browse::filter', 'All');
       this.set('filteredSet', models.tales);
     } else if (filter === 'Mine') {
+      window.localStorage.setItem('browse::filter', 'Mine');
       const userId = this.get('userAuth').getCurrentUserID();
       this.set('filteredSet', models.tales.filter(m => m.creatorId === userId));
     } else if (filter === 'Published') {
+      window.localStorage.setItem('browse::filter', 'Published');
       this.set('filteredSet', models.tales.filter(m => {
         return m.publishInfo.length;
       }));
     } else if (filter === 'Recent') {
+      window.localStorage.setItem('browse::filter', 'Recent');
       const recentTales = this.get('internalState').getRecentTales();
       this.set('filteredSet', models.tales.filter(m => {
         return (recentTales.indexOf(m.get('id')) > -1);


### PR DESCRIPTION
## Problem
The Browse view doesn't remember the state of the selected filters.

Fixes #564 

## Approach
* Save filter state in `localStorage` when it changes.
* Load from `localStorage` when view initializes.

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Browse view
    * Filter should default to `All Tales`
4. Toggle to `My Tales` and refresh the page
    * You should see that `My Tales` is selected by default
5. Click "View" on a Tale, then click the Back button
    * You should see that `My Tales` is still selected by default