### PR TITLE
Increase max length of tale title on Run view paddleboard

### DIFF
--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -12,7 +12,9 @@
                         {{#if model.copyOfTale}}
                             <a class="ui tiny blue horizontal label">COPY</a>
                         {{/if}}
-                        {{truncate-name model.title 100}}
+                        <p class="ui computer only grid" title="{{model.title}}">{{truncate-name model.title 100}}</p>
+                        <p class="ui tablet only grid" title="{{model.title}}">{{truncate-name model.title 50}}</p>
+                        <p class="ui mobile only grid" title="{{model.title}}">{{truncate-name model.title 20}}</p>
                     </h3>
                     
                     <span>{{tale-authors-to-str model.authors model.creator}}</span>

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -12,7 +12,7 @@
                         {{#if model.copyOfTale}}
                             <a class="ui tiny blue horizontal label">COPY</a>
                         {{/if}}
-                        {{truncate-name model.title}}
+                        {{truncate-name model.title 100}}
                     </h3>
                     
                     <span>{{tale-authors-to-str model.authors model.creator}}</span>


### PR DESCRIPTION
## Problem
Tale title is truncated too early on the Run view's paddleboard.

Fixes #449 

## Approach
Increase the maximum number of characters to `100` before title is truncated.

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a Tale with a long name, if you haven't already
4. Navigate to the Run view for this Tale
    * You should be brought to the Run view for this Tale
    * You should see that 100 characters are allowed in the title before truncation occurs