### PR TITLE
Fixed the case where no filter was set on Browse

### DIFF
--- a/app/components/ui/tale-browser/component.js
+++ b/app/components/ui/tale-browser/component.js
@@ -96,6 +96,8 @@ export default Component.extend({
     const filter = window.localStorage.getItem('browse::filter');
     if (filter) {
       this.actions.selectFilter.call(component, filter);
+    } else {
+      this.actions.selectFilter.call(component, 'All');
     }
     
     // Check if any instance is LAUNCHING


### PR DESCRIPTION
## Problem
A recent change to the filter behavior on the Browse view causes the code to improperly set the filter value when no filter was detected from `localStorage`.

This problem was introduced in #599 and fixes #604

## Approach
Set the filter properly in this case

## How to Test
Prerequisites: clear your `localStorage`, or run in a fresh incognito window

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Browse view
    * You should see a list of all Tales here, with their images properly rendered