### PR TITLE
Disable "Connect Account" / "Connect" buttons when necessary

### DIFF
--- a/app/helpers/array-empty.js
+++ b/app/helpers/array-empty.js
@@ -1,0 +1,6 @@
+// app/helpers/array-empty.js
+
+import Ember from 'ember';
+
+const empty = (params) => !params[0] || params[0].length === 0;
+export default Ember.Helper.helper(empty);

--- a/app/helpers/array-not-empty.js
+++ b/app/helpers/array-not-empty.js
@@ -1,0 +1,6 @@
+// app/helpers/array-not-empty.js
+
+import Ember from 'ember';
+
+const notEmpty = (params) => params[0] && params[0].length !== 0;
+export default Ember.Helper.helper(notEmpty);

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -19,6 +19,8 @@
             <div class="ui segment">
               {{#if (or (eq provider.state 'authorized') (eq provider.state 'preauthorized'))}}
                 <button class="ui basic right floated blue button disabled" disabled="true">Connect Account</button>
+              {{else if (and (eq provider.type 'apikey') (array-empty provider.targets))}}
+                <button class="ui basic right floated blue button disabled" disabled="true">Connect Account</button>
               {{else if (or (eq provider.type 'bearer') (eq provider.type 'dataone'))}}
                 <button class="ui basic right floated blue button" {{action 'connectOAuthProvider' provider}}>Connect Account</button>
               {{else if (eq provider.type 'apikey')}}
@@ -110,9 +112,16 @@
     <a class="ui deny button" {{action 'clearConnectExtAcctModal'}}>
       Cancel
     </a>
-    <a class="ui positive primary right button" {{action 'connectProvider' selectedProvider newResourceServer newApiKey}}>
-      Connect
-    </a>
+    
+    {{#if (or (not newResourceServer) (not newApiKey))}}
+      <a class="ui positive primary right button disabled" disabled="true">
+        Connect
+      </a>
+    {{else}}
+      <a class="ui positive primary right button" {{action 'connectProvider' selectedProvider newResourceServer newApiKey}}>
+        Connect
+      </a>
+    {{/if}}
   </div>
 </div>
 


### PR DESCRIPTION
## Problem
The "Connect Account" button is clickable even when there are no more available connections.

Fixes #607

Furthermore, the `connect-apikey-modal` allows users to submit without entering any/all required fields. 

## Approach
* Disable "Connect Account" for APIkey providers when user has already added all possible connections
* Disable "Connect" submit button on `connect-apikey-modal` without user input

## How to Test
Preconditions: Remove all Zenodo and/or Dataverse external account connections

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Settings page
4. Beside Dataverse and/or Zenodo, click "Connect Account"
    * The `connect-apikey-modal` should display
    * The "Connect" button at the bottom=right of the modal should be disable
5. Choose a resource server and enter any value for the API key
    * The "Connect" button should now be enabled
6. Click "Connect" to submit the new API key
    * The modal should close
    * A new entry should appear under the provider indicating that your are now `Authorized on...` the resource server you just chose 
    * A Disconnect button should appear beside the `Authorized on...` entry
7. Repeat for all Dataverse and/or Zenodo resource servers
    * After adding the last Dataverse and/or Zenodo resource server, you should see that the "Connect Account" button becomes disabled