### PR TITLE
Redirect to run page on errors

### DIFF
--- a/app/components/ui/copy-on-launch-modal/component.js
+++ b/app/components/ui/copy-on-launch-modal/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import EmberObject from '@ember/object';
+import { later } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import $ from 'jquery';
 import layout from './template';
@@ -31,7 +32,12 @@ export default Component.extend({
               let handleLaunchError = (tale, err) => {
                 console.error('Failed to launch Tale', err);
                 self.set("errorMessage", err.message);
-                $('.ui.modal.compose-error').modal('show');
+                $('.ui.modal.compose-error').modal({
+                  onHide: function(element) {
+                    later(() => { self.router.transitionTo('run.view', tale._id); }, 500);
+                    return true;
+                  },
+                }).modal('show');
               };
               
             self.get('apiCall').copyTale(originalTale).then(taleCopy => {

--- a/app/components/ui/copy-on-launch-modal/template.hbs
+++ b/app/components/ui/copy-on-launch-modal/template.hbs
@@ -22,7 +22,7 @@
   </div>
 </div>
 
-<div class="ui copy-error modal">
+<div id="copy-error-modal" class="ui copy-error modal">
     <div class="header">
         Tale Error
     </div>

--- a/app/components/ui/create-tale-modal/component.js
+++ b/app/components/ui/create-tale-modal/component.js
@@ -150,14 +150,12 @@ export default Component.extend({
     const self = this;
     self.set("creatingTale", false);
     self.handleError(e);
-    $('.ui.modal.compose-error').modal('show');
     $('.ui.modal.compose-error').modal({
       onHide: function(element) {
-        //$('.ui.modal.compose-error').modal('hide');
         later(() => { self.router.transitionTo('run.view', self.newTale._id); }, 500);
         return true;
       },
-    });
+    }).modal('show');
   },
 
   // ---------------------------------------------------------------------------------

--- a/app/components/ui/create-tale-modal/template.hbs
+++ b/app/components/ui/create-tale-modal/template.hbs
@@ -98,7 +98,7 @@
 {{/ui-modal}}
 
 
-<div class="ui compose-error modal">
+<div id="compose-error-modal" class="ui compose-error modal">
   <div class="header">
     Error Launching Tale
   </div>


### PR DESCRIPTION
Redirects the user to the Tale if there is an error launching the Tale. This behaviour was built into the create-tale-modal, but we were showing the modal before loading this behavior.

This is a fix for #597 . After navigating to the run page and back the browse, users should see their Tale

### Test Steps:
1. Checkout and deploy
1. Launch two Tales
1. Copy + Launch a Tale
1. After the error message make sure you're brought to the run page
1. Navigate to Browse
1. See your Tale
1. Create and launch a new Tale (with the two instances still running)
1. After the error message note that you're brought to the run page
1. Navigate to Browse
1. See your Tale


Side Note: I found another duplicate modal issue. After viewing the run page and going back to browse... If you copy + launch again you'll get two error modals.