### PR TITLE
Disable Publish button when no repository is selected

### DIFF
--- a/app/components/dashboard/run/left-panel/component.js
+++ b/app/components/dashboard/run/left-panel/component.js
@@ -42,6 +42,7 @@ export default Component.extend(FullScreenMixin, {
     repositories: [],
     // The repository that is currently selected in the dropdown
     selectedRepository: '',
+    disablePublish: true,
   
     instancePoller: observer('model', 'model.instance', function() {
       // If we see an instance that is "Launching", poll until it completes
@@ -455,6 +456,7 @@ export default Component.extend(FullScreenMixin, {
           let selection = this.get('repositories').find((repo) => repo.name === repositoryName);
           if (selection) {
             this.set('selectedRepository', selection);
+            this.set('disablePublish', false);
           } else {
             console.error('Failed to select '+ repositoryName + ' for publishing');
           }

--- a/app/components/dashboard/run/left-panel/template.hbs
+++ b/app/components/dashboard/run/left-panel/template.hbs
@@ -198,8 +198,8 @@
       {{if (eq publishStatus 'success') 'Close' 'Cancel'}}
     </div>
     <div class="ui positive right labeled icon button 
-        {{if (or (eq publishStatus 'success') (or (eq publishStatus 'in_progress') (eq selectedRepositoryName null))) 'disabled'}}" 
-        disabled="{{if (or (eq publishStatus 'success') (or (eq publishStatus 'in_progress') (eq selectedRepositoryName null))) 'true' 'false'}}"
+        {{if (or (eq publishStatus 'success') (or (eq publishStatus 'in_progress')  disablePublish)) 'disabled'}}" 
+        disabled="{{if (or (eq publishStatus 'success') (or (eq publishStatus 'in_progress') disablePublish)) 'true' 'false'}}"
         {{action 'submitPublish'}}>
       {{if (or (eq publishStatus 'initialized') (eq publishStatus 'error')) 'Publish'}}
       {{if (eq publishStatus 'success') 'Published'}}


### PR DESCRIPTION
## Problem
The Publish modal used to prevent the user from submitting if they had not made any selections. Now, it allows for the user to submit an invalid publish request.

Fixes #613 

## Approach
Disable the button once again if no repo is selected

## How to Test
Preconditions: at least 1 zenodo/dataone account connection, at least 1 Tale created

1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Run view for a Tale that you own
4. Expand the ... menu and click "Publish Tale..."
    * You should see that the Publish button is once disabled by default
5. Select a repository from the dropdown
    * You should see that the Publish button is now enabled