### PR TITLE
Customize docs_href with currently selected resource_server. Fixes #616

### DIFF
--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -18,6 +18,7 @@ export default Controller.extend({
     model: null,
     newApiKey: '',
     newResourceServer: '',
+    generateKeyUrl: '',
     
     providers: A([]),
     providerTargets: O({}),
@@ -104,8 +105,17 @@ export default Controller.extend({
     },
     
     actions: {
-      setResourceServer(selected) {
-        this.set('newResourceServer', selected);
+      setGenerateKeyUrl(selected) {
+        const self = this;
+        const resourceServer = selected.target.value;
+        if (resourceServer) {
+          let provider = self.get('selectedProvider');
+          let url = new URL(provider.docs_href)
+          url.hostname = resourceServer;
+          self.set('generateKeyUrl', url.toString());
+        } else {
+          self.set('generateKeyUrl', '');
+        }
       },
       
       connectOAuthProvider(provider) {
@@ -130,6 +140,7 @@ export default Controller.extend({
         $('#newResourceServerDropdown').dropdown('clear');
         component.set('newApiKey', '');
         component.set('newResourceServer', '');
+        component.set('generateKeyUrl', '');
       },
       
       connectProvider(provider, newResourceServer, newApiKey, keyType = 'apikey') {

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -85,7 +85,7 @@
       <div class="two fields">
         <div class="field">
           <label>{{selectedProvider.fullName}} Repository</label>
-          <div id="newResourceServerDropdown" class="ui fluid selection dropdown">
+          <div id="newResourceServerDropdown" class="ui fluid selection dropdown" onChange={{action 'setGenerateKeyUrl'}}>
             {{input type="hidden" name="newResourceServer" value=newResourceServer}}
             <i class="dropdown icon"></i>
             <div class="default text">Choose a repository...</div>
@@ -98,8 +98,8 @@
         </div>
         <div class="field">
           <label>API Token 
-            {{#if selectedProvider.docs_href}}
-              <a href="{{selectedProvider.docs_href}}" style="float:right; font-weight:normal" target="_blank">Get from {{selectedProvider.fullName}} <i class="external square alternate icon"></i></a>
+            {{#if generateKeyUrl}}
+              <a href="{{generateKeyUrl}}" style="float:right; font-weight:normal" target="_blank">Get from {{selectedProvider.fullName}} <i class="external square alternate icon"></i></a>
             {{/if}}
           </label>
           {{input type="text" name="API Token" placeholder="Enter an API key" value=newApiKey}}


### PR DESCRIPTION
### How to test?

1. Deploy this and make sure you're running latest `girder_wholetale` cause I sneaked in https://github.com/whole-tale/girder_wholetale/pull/408
1. Navigate to https://dashboard.local.wholetale.org/settings and click "connect" next to Dataverse.
1. Link ("Get from Dataverse") should not be present until you select the resource server
1. Select resource server and hover mouse over `Get from Dataverse` and confirm that hostname in the href matches `resource_server`
1. Repeat previous step for different resource server.
1. (optionally) verify that links go into the right place
1. Repeat for Zenodo