### PR TITLE
Fixed multiple files being removed from view on delete

### DIFF
--- a/app/components/ui/files/directory-browser/component.js
+++ b/app/components/ui/files/directory-browser/component.js
@@ -218,20 +218,7 @@ export default Component.extend({
     remove(file) {
       const self = this;
       self.get('internalState').removeFolderFromRecentFolders(file.id);
-      let fileType = file.get('_modelType');
-      file.destroyRecord().then(() => {
-        if (fileType === 'item') {
-          const files = self.fileList.toArray();
-          const index = files.indexOf(file);
-          files.splice(index, 1);
-          self.set('fileList', files);
-        } else if (fileType === 'folder') {
-          const folders = self.folderList.toArray();
-          const index = folders.indexOf(file);
-          folders.splice(index, 1);
-          self.set('folderList', folders);
-        }
-      });
+      file.destroyRecord();
     },
 
     confirmedRemove() {


### PR DESCRIPTION
## Problem
While fixing #610, an overzealous change was added to `remove(file)` that was not necessary. Ember-Data apparently will automatically remove the model from view when calling `destroyRecord()`, so there was no need to add additional handling in the `.then()` clause to remove this from view. 

Fixes #620 

## Approach
Remove the `.then()` clause from the promise

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a Tale, if you haven't already
4. Navigate to Run > Files > Home or Run > Files > Tale Workspace
5. Upload a few files (5 or so)
6. Remove the second to last file from the list
    * You should see that only the file that you chose to Remove disappears
7. Refresh the page
    * You should see the same list of files appear, and the file you just removed should now be missing